### PR TITLE
Add additional error information

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/service/WatsonService.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/WatsonService.java
@@ -68,8 +68,6 @@ public abstract class WatsonService {
   private static final String URL = "url";
   private static final String PATH_AUTHORIZATION_V1_TOKEN = "/v1/token";
   private static final String AUTHORIZATION = "authorization";
-  private static final String MESSAGE_ERROR_3 = "message";
-  private static final String MESSAGE_ERROR_2 = "error_message";
   private static final String BASIC = "Basic ";
   private static final String BEARER = "Bearer ";
   private static final String APIKEY_AS_USERNAME = "apikey";
@@ -98,8 +96,6 @@ public abstract class WatsonService {
   /** The Constant MESSAGE_CODE. */
   protected static final String MESSAGE_CODE = "code";
 
-  /** The Constant MESSAGE_ERROR. */
-  protected static final String MESSAGE_ERROR = "error";
 
   /** The Constant VERSION. */
   protected static final String VERSION = "version";
@@ -309,38 +305,6 @@ public abstract class WatsonService {
   }
 
   /**
-   * Gets the error message from a JSON response.
-   *
-   * <pre>
-   * {
-   *   code: 400
-   *   error: 'bad request'
-   * }
-   * </pre>
-   *
-   * @param response the HTTP response
-   * @return the error message from the JSON object
-   */
-  private String getErrorMessage(Response response) {
-    String error = ResponseUtils.getString(response);
-    try {
-
-      final JsonObject jsonObject = ResponseUtils.getJsonObject(error);
-      if (jsonObject.has(MESSAGE_ERROR)) {
-        error = jsonObject.get(MESSAGE_ERROR).getAsString();
-      } else if (jsonObject.has(MESSAGE_ERROR_2)) {
-        error = jsonObject.get(MESSAGE_ERROR_2).getAsString();
-      } else if (jsonObject.has(MESSAGE_ERROR_3)) {
-        error = jsonObject.get(MESSAGE_ERROR_3).getAsString();
-      }
-    } catch (final Exception e) {
-      // Ignore any kind of exception parsing the json and use fallback String version of response
-    }
-
-    return error;
-  }
-
-  /**
    * Gets the name.
    *
    * @return the name
@@ -494,39 +458,31 @@ public abstract class WatsonService {
       return converter.convert(response);
     }
 
-    // There was a Client Error 4xx or a Server Error 5xx
-    // Get the error message and create the exception
-    final String error = getErrorMessage(response);
-    LOG.log(Level.SEVERE, response.request().method() + " " + response.request().url().toString() + ", status: "
-        + response.code() + ", error: " + error);
-
     switch (response.code()) {
       case HttpStatus.BAD_REQUEST: // HTTP 400
-        throw new BadRequestException(error != null ? error : "Bad Request", response);
+        throw new BadRequestException(response);
       case HttpStatus.UNAUTHORIZED: // HTTP 401
-        throw new UnauthorizedException("Unauthorized: Access is denied due to invalid credentials. "
-                                        + "Tip: Did you set the Endpoint?", response);
+        throw new UnauthorizedException(response);
       case HttpStatus.FORBIDDEN: // HTTP 403
-        throw new ForbiddenException(error != null ? error : "Forbidden: Service refuse the request", response);
+        throw new ForbiddenException(response);
       case HttpStatus.NOT_FOUND: // HTTP 404
-        throw new NotFoundException(error != null ? error : "Not found", response);
+        throw new NotFoundException(response);
       case HttpStatus.NOT_ACCEPTABLE: // HTTP 406
-        throw new ForbiddenException(error != null ? error : "Forbidden: Service refuse the request", response);
+        throw new ForbiddenException(response);
       case HttpStatus.CONFLICT: // HTTP 409
-        throw new ConflictException(error != null ? error : "", response);
+        throw new ConflictException(response);
       case HttpStatus.REQUEST_TOO_LONG: // HTTP 413
-        throw new RequestTooLargeException(error != null ? error
-            : "Request too large: " + "The request entity is larger than the server is able to process", response);
+        throw new RequestTooLargeException(response);
       case HttpStatus.UNSUPPORTED_MEDIA_TYPE: // HTTP 415
-        throw new UnsupportedException(error != null ? error : "Unsupported Media Type", response);
+        throw new UnsupportedException(response);
       case HttpStatus.TOO_MANY_REQUESTS: // HTTP 429
-        throw new TooManyRequestsException(error != null ? error : "Too many requests", response);
+        throw new TooManyRequestsException(response);
       case HttpStatus.INTERNAL_SERVER_ERROR: // HTTP 500
-        throw new InternalServerErrorException(error != null ? error : "Internal Server Error", response);
+        throw new InternalServerErrorException(response);
       case HttpStatus.SERVICE_UNAVAILABLE: // HTTP 503
-        throw new ServiceUnavailableException(error != null ? error : "Service Unavailable", response);
+        throw new ServiceUnavailableException(response);
       default: // other errors
-        throw new ServiceResponseException(response.code(), error, response);
+        throw new ServiceResponseException(response.code(), response);
     }
   }
 

--- a/src/main/java/com/ibm/cloud/sdk/core/service/WatsonService.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/WatsonService.java
@@ -12,7 +12,6 @@
  */
 package com.ibm.cloud.sdk.core.service;
 
-import com.google.gson.JsonObject;
 import com.ibm.cloud.sdk.core.http.HttpClientSingleton;
 import com.ibm.cloud.sdk.core.http.HttpConfigOptions;
 import com.ibm.cloud.sdk.core.http.HttpHeaders;
@@ -39,8 +38,6 @@ import com.ibm.cloud.sdk.core.service.security.IamTokenManager;
 import com.ibm.cloud.sdk.core.util.CredentialUtils;
 import com.ibm.cloud.sdk.core.util.RequestUtils;
 import com.ibm.cloud.sdk.core.util.ResponseConverterUtils;
-import com.ibm.cloud.sdk.core.util.ResponseUtils;
-
 import jersey.repackaged.jsr166e.CompletableFuture;
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -54,7 +51,6 @@ import okhttp3.Response;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/BadRequestException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/BadRequestException.java
@@ -27,11 +27,10 @@ public class BadRequestException extends ServiceResponseException {
   /**
    * Instantiates a new BadRequest Exception. HTTP 400
    *
-   * @param message the error message
    * @param response the HTTP response
    */
-  public BadRequestException(String message, Response response) {
-    super(HttpStatus.BAD_REQUEST, message, response);
+  public BadRequestException(Response response) {
+    super(HttpStatus.BAD_REQUEST, response);
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/BadRequestException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/BadRequestException.java
@@ -31,6 +31,9 @@ public class BadRequestException extends ServiceResponseException {
    */
   public BadRequestException(Response response) {
     super(HttpStatus.BAD_REQUEST, response);
+    if (this.getMessage() == null) {
+      this.setMessage("Bad request");
+    }
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/ConflictException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/ConflictException.java
@@ -33,6 +33,9 @@ public class ConflictException extends ServiceResponseException {
    */
   public ConflictException(Response response) {
     super(HttpStatus.CONFLICT, response);
+    if (this.getMessage() == null) {
+      this.setMessage("");
+    }
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/ConflictException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/ConflictException.java
@@ -29,11 +29,10 @@ public class ConflictException extends ServiceResponseException {
   /**
    * Instantiates a new Forbidden Exception.
    *
-   * @param message the error message
    * @param response the HTTP response
    */
-  public ConflictException(String message, Response response) {
-    super(HttpStatus.CONFLICT, message, response);
+  public ConflictException(Response response) {
+    super(HttpStatus.CONFLICT, response);
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/ForbiddenException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/ForbiddenException.java
@@ -29,11 +29,10 @@ public class ForbiddenException extends ServiceResponseException {
   /**
    * Instantiates a new Forbidden Exception.
    *
-   * @param message the error message
    * @param response the HTTP response
    */
-  public ForbiddenException(String message, Response response) {
-    super(HttpStatus.FORBIDDEN, message, response);
+  public ForbiddenException(Response response) {
+    super(HttpStatus.FORBIDDEN, response);
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/ForbiddenException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/ForbiddenException.java
@@ -33,6 +33,9 @@ public class ForbiddenException extends ServiceResponseException {
    */
   public ForbiddenException(Response response) {
     super(HttpStatus.FORBIDDEN, response);
+    if (this.getMessage() == null) {
+      this.setMessage("Forbidden: Service refused the request");
+    }
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/InternalServerErrorException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/InternalServerErrorException.java
@@ -33,6 +33,9 @@ public class InternalServerErrorException extends ServiceResponseException {
    */
   public InternalServerErrorException(Response response) {
     super(HttpStatus.INTERNAL_SERVER_ERROR, response);
+    if (this.getMessage() == null) {
+      this.setMessage("Internal server error");
+    }
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/InternalServerErrorException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/InternalServerErrorException.java
@@ -29,11 +29,10 @@ public class InternalServerErrorException extends ServiceResponseException {
   /**
    * Instantiates a new Internal Server Error Exception.
    *
-   * @param message the error message
    * @param response the HTTP response
    */
-  public InternalServerErrorException(String message, Response response) {
-    super(HttpStatus.INTERNAL_SERVER_ERROR, message, response);
+  public InternalServerErrorException(Response response) {
+    super(HttpStatus.INTERNAL_SERVER_ERROR, response);
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/NotFoundException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/NotFoundException.java
@@ -29,11 +29,10 @@ public class NotFoundException extends ServiceResponseException {
   /**
    * Instantiates a new not found exception.
    *
-   * @param message the message
    * @param response the HTTP response
    */
-  public NotFoundException(String message, Response response) {
-    super(HttpStatus.NOT_FOUND, message, response);
+  public NotFoundException(Response response) {
+    super(HttpStatus.NOT_FOUND, response);
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/NotFoundException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/NotFoundException.java
@@ -33,6 +33,9 @@ public class NotFoundException extends ServiceResponseException {
    */
   public NotFoundException(Response response) {
     super(HttpStatus.NOT_FOUND, response);
+    if (this.getMessage() == null) {
+      this.setMessage("Not found");
+    }
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/RequestTooLargeException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/RequestTooLargeException.java
@@ -29,11 +29,10 @@ public class RequestTooLargeException extends ServiceResponseException {
   /**
    * Instantiates a new Request Too Large Exception.
    *
-   * @param message the error message
    * @param response the HTTP response
    */
-  public RequestTooLargeException(String message, Response response) {
-    super(HttpStatus.REQUEST_TOO_LONG, message, response);
+  public RequestTooLargeException(Response response) {
+    super(HttpStatus.REQUEST_TOO_LONG, response);
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/RequestTooLargeException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/RequestTooLargeException.java
@@ -33,6 +33,9 @@ public class RequestTooLargeException extends ServiceResponseException {
    */
   public RequestTooLargeException(Response response) {
     super(HttpStatus.REQUEST_TOO_LONG, response);
+    if (this.getMessage() == null) {
+      this.setMessage("Request too large: The request entity is larger than the server is able to process");
+    }
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceResponseException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceResponseException.java
@@ -34,6 +34,7 @@ public class ServiceResponseException extends RuntimeException {
   private static final String MESSAGE_ERROR = "error";
   private static final String MESSAGE_ERROR_2 = "error_message";
   private static final String MESSAGE_ERROR_3 = "message";
+  private static final String[] ERROR_KEYS = { MESSAGE_ERROR, MESSAGE_ERROR_2, MESSAGE_ERROR_3 };
 
   private static final Type debuggingInfoType = new TypeToken<Map<String, Object>>() { }.getType();
 
@@ -58,12 +59,11 @@ public class ServiceResponseException extends RuntimeException {
     String responseString = ResponseUtils.getString(response);
     try {
       final JsonObject jsonObject = ResponseUtils.getJsonObject(responseString);
-      if (jsonObject.has(MESSAGE_ERROR)) {
-        this.message = jsonObject.remove(MESSAGE_ERROR).getAsString();
-      } else if (jsonObject.has(MESSAGE_ERROR_2)) {
-        this.message = jsonObject.remove(MESSAGE_ERROR_2).getAsString();
-      } else if (jsonObject.has(MESSAGE_ERROR_3)) {
-        this.message = jsonObject.remove(MESSAGE_ERROR_3).getAsString();
+      for (String errorKey : ERROR_KEYS) {
+        if (jsonObject.has(errorKey)) {
+          this.message = jsonObject.remove(errorKey).getAsString();
+          break;
+        }
       }
       this.debuggingInfo = GsonSingleton.getGson().fromJson(jsonObject, debuggingInfoType);
     } catch (final Exception e) {

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceResponseException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceResponseException.java
@@ -29,12 +29,12 @@ public class ServiceResponseException extends RuntimeException {
   /** The Constant serialVersionUID. */
   private static final long serialVersionUID = 1L;
 
-  /** Potential error message keys */
+  /** Potential error message keys. */
   private static final String MESSAGE_ERROR = "error";
   private static final String MESSAGE_ERROR_2 = "error_message";
   private static final String MESSAGE_ERROR_3 = "message";
 
-  private static final Type debuggingInfoType = new TypeToken<Map<String, String>>() {}.getType();
+  private static final Type debuggingInfoType = new TypeToken<Map<String, String>>() { }.getType();
 
   /** The status code. */
   private final int statusCode;

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceResponseException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceResponseException.java
@@ -91,6 +91,15 @@ public class ServiceResponseException extends RuntimeException {
   }
 
   /**
+   * Sets the error message.
+   *
+   * @param message the error message
+   */
+  protected void setMessage(String message) {
+    this.message = message;
+  }
+
+  /**
    * Gets the headers.
    *
    * @return the headers

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceResponseException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceResponseException.java
@@ -34,13 +34,13 @@ public class ServiceResponseException extends RuntimeException {
   private static final String MESSAGE_ERROR_2 = "error_message";
   private static final String MESSAGE_ERROR_3 = "message";
 
-  private static final Type debuggingInfoType = new TypeToken<Map<String, String>>() { }.getType();
+  private static final Type debuggingInfoType = new TypeToken<Map<String, Object>>() { }.getType();
 
   /** The status code. */
   private final int statusCode;
 
   private String message;
-  private Map<String, String> debuggingInfo;
+  private Map<String, Object> debuggingInfo;
 
   /**
    * Instantiates a new Service Response Exception.
@@ -92,7 +92,7 @@ public class ServiceResponseException extends RuntimeException {
    *
    * @return the response information other than the error message
    */
-  public Map<String, String> getDebuggingInfo() {
+  public Map<String, Object> getDebuggingInfo() {
     return debuggingInfo;
   }
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceResponseException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceResponseException.java
@@ -14,6 +14,7 @@ package com.ibm.cloud.sdk.core.service.exception;
 
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
+import com.ibm.cloud.sdk.core.http.Headers;
 import com.ibm.cloud.sdk.core.util.GsonSingleton;
 import com.ibm.cloud.sdk.core.util.ResponseUtils;
 import okhttp3.Response;
@@ -40,6 +41,7 @@ public class ServiceResponseException extends RuntimeException {
   private final int statusCode;
 
   private String message;
+  private Headers headers;
   private Map<String, Object> debuggingInfo;
 
   /**
@@ -51,6 +53,7 @@ public class ServiceResponseException extends RuntimeException {
   public ServiceResponseException(int statusCode, Response response) {
     super();
     this.statusCode = statusCode;
+    this.headers = new Headers(response.headers());
 
     String responseString = ResponseUtils.getString(response);
     try {
@@ -85,6 +88,15 @@ public class ServiceResponseException extends RuntimeException {
    */
   public String getMessage() {
     return message;
+  }
+
+  /**
+   * Gets the headers.
+   *
+   * @return the headers
+   */
+  public Headers getHeaders() {
+    return headers;
   }
 
   /**

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceUnavailableException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceUnavailableException.java
@@ -33,6 +33,9 @@ public class ServiceUnavailableException extends ServiceResponseException {
    */
   public ServiceUnavailableException(Response response) {
     super(HttpStatus.SERVICE_UNAVAILABLE, response);
+    if (this.getMessage() == null) {
+      this.setMessage("Service unavailable");
+    }
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceUnavailableException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceUnavailableException.java
@@ -29,11 +29,10 @@ public class ServiceUnavailableException extends ServiceResponseException {
   /**
    * Instantiates a new Service Unavailable Exception.
    *
-   * @param message the error message
    * @param response the HTTP response
    */
-  public ServiceUnavailableException(String message, Response response) {
-    super(HttpStatus.SERVICE_UNAVAILABLE, message, response);
+  public ServiceUnavailableException(Response response) {
+    super(HttpStatus.SERVICE_UNAVAILABLE, response);
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/TooManyRequestsException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/TooManyRequestsException.java
@@ -32,6 +32,9 @@ public class TooManyRequestsException extends ServiceResponseException {
    */
   public TooManyRequestsException(Response response) {
     super(TOO_MANY_REQUESTS, response);
+    if (this.getMessage() == null) {
+      this.setMessage("Too many requests");
+    }
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/TooManyRequestsException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/TooManyRequestsException.java
@@ -28,11 +28,10 @@ public class TooManyRequestsException extends ServiceResponseException {
   /**
    * Instantiates a new Too Many Requests Exception.
    *
-   * @param message the error message
    * @param response the HTTP response
    */
-  public TooManyRequestsException(String message, Response response) {
-    super(TOO_MANY_REQUESTS, message, response);
+  public TooManyRequestsException(Response response) {
+    super(TOO_MANY_REQUESTS, response);
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/UnauthorizedException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/UnauthorizedException.java
@@ -33,6 +33,9 @@ public class UnauthorizedException extends ServiceResponseException {
    */
   public UnauthorizedException(Response response) {
     super(HttpStatus.UNAUTHORIZED, response);
+    if (this.getMessage() == null) {
+      this.setMessage("Unauthorized: Access is denied due to invalid credentials. Tip: Did you set the endpoint?");
+    }
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/UnauthorizedException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/UnauthorizedException.java
@@ -29,11 +29,10 @@ public class UnauthorizedException extends ServiceResponseException {
   /**
    * Instantiates a new Unauthorized Exception.
    *
-   * @param message the error message
    * @param response the HTTP response
    */
-  public UnauthorizedException(String message, Response response) {
-    super(HttpStatus.UNAUTHORIZED, message, response);
+  public UnauthorizedException(Response response) {
+    super(HttpStatus.UNAUTHORIZED, response);
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/UnsupportedException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/UnsupportedException.java
@@ -29,11 +29,10 @@ public class UnsupportedException extends ServiceResponseException {
   /**
    * Instantiates a new unsupported Exception.
    *
-   * @param message the message
    * @param response the HTTP response
    */
-  public UnsupportedException(String message, Response response) {
-    super(HttpStatus.UNSUPPORTED_MEDIA_TYPE, message, response);
+  public UnsupportedException(Response response) {
+    super(HttpStatus.UNSUPPORTED_MEDIA_TYPE, response);
   }
 
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/UnsupportedException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/UnsupportedException.java
@@ -33,6 +33,9 @@ public class UnsupportedException extends ServiceResponseException {
    */
   public UnsupportedException(Response response) {
     super(HttpStatus.UNSUPPORTED_MEDIA_TYPE, response);
+    if (this.getMessage() == null) {
+      this.setMessage("Unsupported media type");
+    }
   }
 
 }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/ErrorResponseTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/ErrorResponseTest.java
@@ -44,11 +44,11 @@ public class ErrorResponseTest extends WatsonServiceUnitTest {
 
     private static final String SERVICE_NAME = "test";
 
-    public TestService() {
+    TestService() {
       super(SERVICE_NAME);
     }
 
-    public ServiceCall<GenericModel> testMethod() {
+    ServiceCall<GenericModel> testMethod() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getEndPoint() + "/v1/test"));
       return createServiceCall(builder.build(), ResponseConverterUtils.getObject(GenericModel.class));
     }
@@ -110,7 +110,7 @@ public class ErrorResponseTest extends WatsonServiceUnitTest {
       assertTrue(e instanceof UnauthorizedException);
       UnauthorizedException ex = (UnauthorizedException) e;
       assertEquals(401, ex.getStatusCode());
-      assertTrue(ex.getMessage().startsWith("Unauthorized: Access is denied due to invalid credentials."));
+      assertEquals(message, ex.getMessage());
     }
   }
 
@@ -146,7 +146,8 @@ public class ErrorResponseTest extends WatsonServiceUnitTest {
     server.enqueue(new MockResponse()
         .setResponseCode(404)
         .addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON)
-        .setBody("{\"error\": \"" + message + "\"}"));
+        .setBody("{\"error\": \"" + message + "\", \"level\": \"ERROR\"," +
+            " \"correlationId\": \"c8a0293e-3378-4ef4-9226-2bcce44b4ee7\"}"));
 
     try {
       service.testMethod().execute();

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/ErrorResponseTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/ErrorResponseTest.java
@@ -29,7 +29,6 @@ import com.ibm.cloud.sdk.core.service.exception.UnsupportedException;
 import com.ibm.cloud.sdk.core.service.model.GenericModel;
 import com.ibm.cloud.sdk.core.test.WatsonServiceUnitTest;
 import com.ibm.cloud.sdk.core.util.ResponseConverterUtils;
-
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
 import org.junit.Before;
@@ -287,6 +286,8 @@ public class ErrorResponseTest extends WatsonServiceUnitTest {
       ServiceUnavailableException ex = (ServiceUnavailableException) e;
       assertEquals(503, ex.getStatusCode());
       assertEquals(message, ex.getMessage());
+      assertTrue(ex.getHeaders().names().contains(CONTENT_TYPE));
+      assertTrue(ex.getHeaders().values(CONTENT_TYPE).contains(HttpMediaType.APPLICATION_JSON));
     }
   }
 


### PR DESCRIPTION
An issue was submitted a while back where users using a certain API couldn't retrieve a `correlation_id` field in their error response due to the way we were handling and wrapping errors. This field was particularly important for support people trying to resolve errors.

This PR changes the main exception class `ServiceResponseException` to handle parsing for error messages, which used to be done in `WatsonService` it also changes what is provided for the user, removing the raw `Response` object in favor of `message` (the parsed error message) and `debuggingInfo`, which is a `Map` of the rest of the response.

A test has been added to validate the debugging information.