### PR TITLE
Expose tests in library

### DIFF
--- a/build/bintray-config.template
+++ b/build/bintray-config.template
@@ -26,6 +26,10 @@
       "uploadPattern": "com/ibm/cloud/sdk-core/${TRAVIS_TAG}/sdk-core-${TRAVIS_TAG}-javadoc.jar"
     },
     {
+      "includePattern": "target/sdk-core-${TRAVIS_TAG}-tests.jar",
+      "uploadPattern": "com/ibm/cloud/sdk-core/${TRAVIS_TAG}/sdk-core-${TRAVIS_TAG}-tests.jar"
+    },
+    {
       "includePattern": "pom.xml",
       "uploadPattern": "com/ibm/cloud/sdk-core/${TRAVIS_TAG}/sdk-core-${TRAVIS_TAG}.pom"
     }

--- a/build/sync2MC.sh
+++ b/build/sync2MC.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ $# -lt 5 ]
+if [ $# -lt 6 ]
 then
     echo "
  Syntax:  

--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,18 @@
                 <!-- <configuration> <suiteXmlFiles> <suiteXmlFile>src/test/java/testng.xml</suiteXmlFile> 
                     </suiteXmlFiles> </configuration> -->
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This PR adds a `-tests` jar to allow for pulling base test classes and utilities in the Watson service classes. This approach was taken from the [Maven documentation](http://maven.apache.org/guides/mini/guide-attached-tests.html).