### PR TITLE
Add method to just get system info

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/util/RequestUtils.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/RequestUtils.java
@@ -165,7 +165,16 @@ public final class RequestUtils {
       details.add(propertyName + "=" + System.getProperty(propertyName));
     }
 
-    return "ibm-java-sdk-core/" + loadCoreVersion() + " (" + RequestUtils.join(details, "; ") + ")";
+    return "ibm-java-sdk-core-" + loadCoreVersion() + " " + getSystemInfo();
+  }
+
+  public static String getSystemInfo() {
+    final List<String> details = new ArrayList<>();
+    for (String propertyName : properties) {
+      details.add(propertyName + "=" + System.getProperty(propertyName));
+    }
+
+    return "(" + RequestUtils.join(details, "; ") + ")";
   }
 
   /**

--- a/src/test/java/com/ibm/cloud/sdk/core/test/util/RequestUtilsTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/util/RequestUtilsTest.java
@@ -109,6 +109,6 @@ public class RequestUtilsTest {
   @Test
   public void testUserAgent() {
     assertNotNull(RequestUtils.getUserAgent());
-    assertTrue(RequestUtils.getUserAgent().startsWith("ibm-java-sdk-core/"));
+    assertTrue(RequestUtils.getUserAgent().startsWith("ibm-java-sdk-core-"));
   }
 }


### PR DESCRIPTION
This PR makes a small change to allow external packages to _just_ grab system information, which currently consists of the Java vendor, Java version OS architecture, OS name, and OS version.

This change is related to a Slack discussion that was had where we decided that by default, the core version would be included in the `User-Agent` header, but that if a `User-Agent` was provided by an external SDK, they could avoid appending the core version.