### PR TITLE
Serialize null values coming back from service APIs

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/util/GsonSingleton.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/GsonSingleton.java
@@ -45,6 +45,7 @@ public final class GsonSingleton {
       builder.setPrettyPrinting();
     }
     builder.disableHtmlEscaping();
+    builder.serializeNulls();
     return builder.create();
   }
 


### PR DESCRIPTION
Related to [this issue](https://github.com/watson-developer-cloud/java-sdk/issues/959).

After some discussion that can be seen in the linked issue, it seems we decided that there are valid use-cases where a service would explicitly return a field with a value of `null`. The change in this PR ensures that those values are not left out of serialization and that users can grab that `null` value in the Java code.