### PR TITLE
Revert old SSL/TLS logic change

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/http/HttpClientSingleton.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/HttpClientSingleton.java
@@ -186,8 +186,8 @@ public class HttpClientSingleton {
 
       X509TrustManager trustManager = (X509TrustManager) trustManagers[0];
 
-      System.setProperty("com.ibm.jsse2.overrideDefaultTLS", "true");
-      SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+      // On IBM JDKs this gets only TLSv1
+      SSLContext sslContext = SSLContext.getInstance("TLS");
 
       sslContext.init(null, new TrustManager[] { trustManager }, null);
       SSLSocketFactory sslSocketFactory = new DelegatingSSLSocketFactory(sslContext.getSocketFactory()) {


### PR DESCRIPTION
A while ago, a change was made to the Java SDK core to try and fix some `SSLHandshakeException`s showing up in Visual Recognition on Oracle JDK 7. The PR to try and make that fix is here: https://github.com/watson-developer-cloud/java-sdk/pull/890

However, there was an issue reported later that this "fix" introduced some other potential problems. Here is that issue: https://github.com/watson-developer-cloud/java-sdk/issues/1020

I went back to investigate by using the old logic and Oracle JDK 7 with Visual Recognition and I didn't run into any problems. Based on the timing of the original occurrence, my guess is it had something to do with the transition to IAM authentication and the new endpoint and was just temporary. Either way, if the original logic works and avoids the potential problems that were reported, I think that's preferred.