### PR TITLE
Only include nulls in serialization when processing API responses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,8 +246,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin-version}</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/ibm/cloud/sdk/core/http/RequestBuilder.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/RequestBuilder.java
@@ -12,6 +12,7 @@
  */
 package com.ibm.cloud.sdk.core.http;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.ibm.cloud.sdk.core.service.BaseService;
 import com.ibm.cloud.sdk.core.util.GsonSingleton;
@@ -333,12 +334,11 @@ public class RequestBuilder {
   public RequestBuilder bodyContent(String contentType, Object jsonContent, Object jsonPatchContent,
     InputStream nonJsonContent) {
     if (contentType != null) {
+      Gson requestGson = GsonSingleton.getGson().newBuilder().serializeNulls().create();
       if (BaseService.isJsonMimeType(contentType)) {
-        this.bodyContent(
-          GsonSingleton.getGson().toJsonTree(jsonContent).getAsJsonObject().toString(), contentType);
+        this.bodyContent(requestGson.toJsonTree(jsonContent).getAsJsonObject().toString(), contentType);
       } else if (BaseService.isJsonPatchMimeType(contentType)) {
-        this.bodyContent(
-          GsonSingleton.getGson().toJsonTree(jsonPatchContent).getAsJsonObject().toString(), contentType);
+        this.bodyContent(requestGson.toJsonTree(jsonPatchContent).getAsJsonObject().toString(), contentType);
       } else {
         this.bodyContent(nonJsonContent, contentType);
       }

--- a/src/main/java/com/ibm/cloud/sdk/core/http/ServiceCall.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/ServiceCall.java
@@ -44,7 +44,7 @@ public interface ServiceCall<T> {
    *
    * @param callback the callback
    */
-  void enqueue(ServiceCallback<? super T> callback);
+  void enqueue(ServiceCallback<T> callback);
 
   /**
    * Reactive request using the RxJava 2 library. See https://github.com/ReactiveX/RxJava. In addition, the wrapped

--- a/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
@@ -490,7 +490,7 @@ public abstract class BaseService {
     }
 
     @Override
-    public void enqueue(final ServiceCallback<? super T> callback) {
+    public void enqueue(final ServiceCallback<T> callback) {
       call.enqueue(new Callback() {
         @Override
         public void onFailure(Call call, IOException e) {

--- a/src/main/java/com/ibm/cloud/sdk/core/service/security/IamTokenManager.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/security/IamTokenManager.java
@@ -182,7 +182,7 @@ public class IamTokenManager {
    * @param request the request for the IAM API
    * @return object containing requested IAM token information
    */
-  private IamToken callIamApi(Request request) {
+  private IamToken callIamApi(final Request request) {
     final IamToken[] returnToken = new IamToken[1];
 
     Thread iamApiCall = new Thread(new Runnable() {

--- a/src/main/java/com/ibm/cloud/sdk/core/util/GsonSingleton.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/GsonSingleton.java
@@ -45,7 +45,6 @@ public final class GsonSingleton {
       builder.setPrettyPrinting();
     }
     builder.disableHtmlEscaping();
-    builder.serializeNulls();
     return builder.create();
   }
 


### PR DESCRIPTION
In [this earlier PR](https://github.com/IBM/java-sdk-core/pull/18), I changed the main GSON instance to always serialize with null values. When testing with the new core, I realized that some API endpoints don't like being sent null values. Originally the change was only made with service responses in mind, so I've tweaked the core logic accordingly. JSON content being sent to the APIs should now behave as before.