### PR TITLE
Error parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <compiler-plugin-version>3.8.0</compiler-plugin-version>
         <okhttp3-version>3.12.1</okhttp3-version>
         <logback-version>1.2.3</logback-version>
-        <guava-version>27.0.1-jre</guava-version>
+        <guava-version>27.1-android</guava-version>
         <gson-version>2.8.5</gson-version>
         <commons-io-version>2.6</commons-io-version>
         <commons-lang3-version>3.8.1</commons-lang3-version>

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceResponseException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceResponseException.java
@@ -31,10 +31,9 @@ public class ServiceResponseException extends RuntimeException {
   private static final long serialVersionUID = 1L;
 
   /** Potential error message keys. */
-  private static final String MESSAGE_ERROR = "error";
-  private static final String MESSAGE_ERROR_2 = "error_message";
-  private static final String MESSAGE_ERROR_3 = "message";
-  private static final String[] ERROR_KEYS = { MESSAGE_ERROR, MESSAGE_ERROR_2, MESSAGE_ERROR_3 };
+  private static final String ERRORS_KEY = "errors";
+  private static final String MESSAGE_STRING = "message";
+  private static final String ERROR_STRING = "error";
 
   private static final Type debuggingInfoType = new TypeToken<Map<String, Object>>() { }.getType();
 
@@ -59,11 +58,13 @@ public class ServiceResponseException extends RuntimeException {
     String responseString = ResponseUtils.getString(response);
     try {
       final JsonObject jsonObject = ResponseUtils.getJsonObject(responseString);
-      for (String errorKey : ERROR_KEYS) {
-        if (jsonObject.has(errorKey)) {
-          this.message = jsonObject.remove(errorKey).getAsString();
-          break;
-        }
+      if (jsonObject.has(ERRORS_KEY)) {
+        this.message = jsonObject.remove(ERRORS_KEY).getAsJsonArray().get(0).getAsJsonObject().remove(MESSAGE_STRING)
+            .getAsString();
+      } else if (jsonObject.has(ERROR_STRING)) {
+        this.message = jsonObject.remove(ERROR_STRING).getAsString();
+      } else if (jsonObject.has(MESSAGE_STRING)) {
+        this.message = jsonObject.remove(MESSAGE_STRING).getAsString();
       }
       this.debuggingInfo = GsonSingleton.getGson().fromJson(jsonObject, debuggingInfoType);
     } catch (final Exception e) {


### PR DESCRIPTION
This PR tweaks the error parsing logic according to [this issue](https://github.ibm.com/Watson/developer-experience/issues/6336).

Additionally, it changes the version of the Guava dependency to work with Java version 1.7, since that's the lowest version we target in the Watson SDK.