### PR TITLE
fix: Allow IAM client_id/secret to be supplied for basicauth header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
-sudo: required
 dist: trusty
 jdk:
 - oraclejdk8

--- a/src/main/java/com/ibm/cloud/sdk/core/service/security/IamTokenManager.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/security/IamTokenManager.java
@@ -25,12 +25,16 @@ import okhttp3.FormBody;
 import okhttp3.Request;
 
 import java.io.IOException;
+import java.util.Base64;
 import java.util.logging.Logger;
 
 /**
  * Retrieves, stores, and refreshes IAM tokens.
  */
 public class IamTokenManager {
+  private static String iamClientId = null;
+  private static String iamSecret = null;
+
   private String userManagedAccessToken;
   private String apiKey;
   private String url;
@@ -39,7 +43,7 @@ public class IamTokenManager {
   private static final Logger LOG = Logger.getLogger(IamTokenManager.class.getName());
   private static final String ERROR_MESSAGE = "Error getting IAM token from API";
   private static final String DEFAULT_AUTHORIZATION = "Basic Yng6Yng=";
-  private static final String DEFAULT_IAM_URL = "https://iam.bluemix.net/identity/token";
+  private static final String DEFAULT_IAM_URL = "https://iam.cloud.ibm.com/identity/token";
   private static final String GRANT_TYPE = "grant_type";
   private static final String REQUEST_GRANT_TYPE = "urn:ibm:params:oauth:grant-type:apikey";
   private static final String REFRESH_GRANT_TYPE = "refresh_token";
@@ -100,7 +104,7 @@ public class IamTokenManager {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(url, new String[0]));
 
     builder.header(HttpHeaders.CONTENT_TYPE, HttpMediaType.APPLICATION_FORM_URLENCODED);
-    builder.header(HttpHeaders.AUTHORIZATION, DEFAULT_AUTHORIZATION);
+    builder.header(HttpHeaders.AUTHORIZATION, getAuthorizationHeaderValue());
 
     FormBody formBody = new FormBody.Builder()
         .add(GRANT_TYPE, REQUEST_GRANT_TYPE)
@@ -122,7 +126,7 @@ public class IamTokenManager {
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(url, new String[0]));
 
     builder.header(HttpHeaders.CONTENT_TYPE, HttpMediaType.APPLICATION_FORM_URLENCODED);
-    builder.header(HttpHeaders.AUTHORIZATION, DEFAULT_AUTHORIZATION);
+    builder.header(HttpHeaders.AUTHORIZATION, getAuthorizationHeaderValue());
 
     FormBody formBody = new FormBody.Builder()
         .add(GRANT_TYPE, REFRESH_GRANT_TYPE)
@@ -217,5 +221,32 @@ public class IamTokenManager {
       e.printStackTrace();
     }
     return returnToken[0];
+  }
+
+  public static String getIamClientId() {
+    return iamClientId;
+  }
+
+  public static void setIamClientId(String iamClientId) {
+    IamTokenManager.iamClientId = iamClientId;
+  }
+
+  public static String getIamSecret() {
+    return iamSecret;
+  }
+
+  public static void setIamSecret(String iamSecret) {
+    IamTokenManager.iamSecret = iamSecret;
+  }
+
+  public static String getAuthorizationHeaderValue() {
+    String result;
+    if (getIamClientId() != null && getIamSecret() != null) {
+      String s = getIamClientId() + ":" + getIamSecret();
+      result = "Basic " + Base64.getEncoder().encodeToString(s.getBytes());
+    } else {
+      result = DEFAULT_AUTHORIZATION;
+    }
+    return result;
   }
 }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/IamManagerTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/IamManagerTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import static com.ibm.cloud.sdk.core.test.TestUtils.loadFixture;
 import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 public class IamManagerTest extends BaseServiceUnitTest {
 
@@ -39,6 +40,26 @@ public class IamManagerTest extends BaseServiceUnitTest {
     url = getMockWebServerUrl();
     expiredTokenData = loadFixture("src/test/resources/expired_iam_token.json", IamToken.class);
     validTokenData = loadFixture("src/test/resources/valid_iam_token.json", IamToken.class);
+  }
+
+  @Test
+  public void testAuthorizationHeader() {
+    // Make sure the default header value is correct.
+    String header1 = IamTokenManager.getAuthorizationHeaderValue();
+    assertEquals(header1, "Basic Yng6Yng=");
+
+    // Now make sure different clientid/secret combinations yield different header values
+
+    IamTokenManager.setIamClientId("myuser");
+    IamTokenManager.setIamSecret("mysecret");
+    String header2 = IamTokenManager.getAuthorizationHeaderValue();
+    assertNotEquals(header1, header2);
+
+    IamTokenManager.setIamClientId("123j10iii38918-afde3");
+    IamTokenManager.setIamSecret("aU4RyzIZdFgZWxEroo1");
+    String header3 = IamTokenManager.getAuthorizationHeaderValue();
+    assertNotEquals(header1, header3);
+    assertNotEquals(header2, header3);
   }
 
   /**


### PR DESCRIPTION
Fixes:  https://github.ibm.com/arf/planning-sdk-squad/issues/851