### PR TITLE
Add release docs to GH pages site on releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,11 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
+  - provider: script
+    script: ".build/push-javadoc-to-gh-pages.sh"
+    skip_cleanup: true
+    on:
+      tags: true
 
 # Ask bintray to sync the just-deployed artifact to maven central
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ deploy:
     on:
       tags: true
   - provider: script
-    script: ".build/push-javadoc-to-gh-pages.sh"
+    script: "./build/push-javadoc-to-gh-pages.sh"
     skip_cleanup: true
     on:
       tags: true

--- a/build/generate-index-html.sh
+++ b/build/generate-index-html.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# based on https://odoepner.wordpress.com/2012/02/17/shell-script-to-generate-simple-index-html/
+
+echo '<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>IBM Java SDK Core</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
+</head>
+<body>
+<div class="container">
+    <div class="page-header">
+        <h1>IBM Java SDK Core</h1>
+    </div>
+
+    <p>Javadoc by branch/tag:</p>
+    <ul>'
+ls docs | grep --invert-match index.html | sed 's/^.*/<li><a href="docs\/&">&<\/a><\/li>/'
+echo '    </ul>
+</div>
+<script>
+    (function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,"script","//www.google-analytics.com/analytics.js","ga");
+    ga("create", "UA-59827755-4", "auto");
+    ga("send", "pageview");
+</script>
+</body>
+</html>'

--- a/build/push-javadoc-to-gh-pages.sh
+++ b/build/push-javadoc-to-gh-pages.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" ]; then
+
+  git config --global user.email "wps@us.ibm.com"
+  git config --global user.name "Watson Github Bot"
+  git clone --quiet --branch=gh-pages https://${GITHUB_OAUTH_TOKEN}@github.com/IBM/java-sdk-core.git gh-pages > /dev/null
+
+  pushd gh-pages
+    # on tagged builds, $TRAVIS_BRANCH is the tag (e.g. v1.2.3), otherwise it's the branch name (e.g. master)
+    rm -rf docs/$TRAVIS_BRANCH
+    mkdir -p docs/$TRAVIS_BRANCH
+    cp -rf ../target/apidocs/* docs/$TRAVIS_BRANCH
+    ../.utility/generate_index_html.sh > index.html
+
+    git add -f .
+    git commit -m "Latest javadoc for $TRAVIS_BRANCH ($TRAVIS_COMMIT)"
+    git push -fq origin gh-pages > /dev/null
+
+  popd
+
+  echo -e "Published Javadoc for build $TRAVIS_BUILD_NUMBER ($TRAVIS_JOB_NUMBER) on branch $TRAVIS_BRANCH.\n"
+
+else
+
+  echo -e "Not publishing docs for build $TRAVIS_BUILD_NUMBER ($TRAVIS_JOB_NUMBER) on branch $TRAVIS_BRANCH of repo $TRAVIS_REPO_SLUG"
+
+fi

--- a/build/push-javadoc-to-gh-pages.sh
+++ b/build/push-javadoc-to-gh-pages.sh
@@ -2,8 +2,6 @@
 
 if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" ]; then
 
-  git config --global user.email "wps@us.ibm.com"
-  git config --global user.name "Watson Github Bot"
   git clone --quiet --branch=gh-pages https://${GITHUB_OAUTH_TOKEN}@github.com/IBM/java-sdk-core.git gh-pages > /dev/null
 
   pushd gh-pages


### PR DESCRIPTION
This PR pulls from very similar work that was done in the Watson Java SDK to publish the Javadoc on releases. I've already added the site URL to the README, and you can find it to reference here: https://ibm.github.io/java-sdk-core/