### PR TITLE
feat(IAM): set client id/secret via IamOptions; corrected terminology

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/service/security/IamOptions.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/security/IamOptions.java
@@ -19,6 +19,9 @@ public class IamOptions {
   private String apiKey;
   private String accessToken;
   private String url;
+  private String clientId;
+  private String clientSecret;
+
 
   public String getApiKey() {
     return apiKey;
@@ -32,10 +35,20 @@ public class IamOptions {
     return url;
   }
 
+  public String getClientId() {
+    return clientId;
+  }
+
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
   public static class Builder {
     private String apiKey;
     private String accessToken;
     private String url;
+    private String clientId;
+    private String clientSecret;
 
     public IamOptions build() {
       return new IamOptions(this);
@@ -55,11 +68,23 @@ public class IamOptions {
       this.url = url;
       return this;
     }
+
+    public Builder clientId(String clientId) {
+      this.clientId = clientId;
+      return this;
+    }
+
+    public Builder clientSecret(String clientSecret) {
+      this.clientSecret = clientSecret;
+      return this;
+    }
   }
 
   private IamOptions(Builder builder) {
     this.apiKey = builder.apiKey;
     this.accessToken = builder.accessToken;
     this.url = builder.url;
+    this.clientId = builder.clientId;
+    this.clientSecret = builder.clientSecret;
   }
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/security/IamTokenManager.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/security/IamTokenManager.java
@@ -32,12 +32,12 @@ import java.util.logging.Logger;
  * Retrieves, stores, and refreshes IAM tokens.
  */
 public class IamTokenManager {
-  private static String iamClientId = null;
-  private static String iamSecret = null;
-
   private String userManagedAccessToken;
   private String apiKey;
   private String url;
+  private String clientId;
+  private String clientSecret;
+
   private IamToken tokenData;
 
   private static final Logger LOG = Logger.getLogger(IamTokenManager.class.getName());
@@ -62,6 +62,8 @@ public class IamTokenManager {
     }
     this.url = (options.getUrl() != null) ? options.getUrl() : DEFAULT_IAM_URL;
     this.userManagedAccessToken = options.getAccessToken();
+    this.clientId = options.getClientId();
+    this.clientSecret = options.getClientSecret();
     tokenData = new IamToken();
   }
 
@@ -223,26 +225,26 @@ public class IamTokenManager {
     return returnToken[0];
   }
 
-  public static String getIamClientId() {
-    return iamClientId;
+  public String getClientId() {
+    return this.clientId;
   }
 
-  public static void setIamClientId(String iamClientId) {
-    IamTokenManager.iamClientId = iamClientId;
+  public void setClientId(String clientId) {
+    this.clientId = clientId;
   }
 
-  public static String getIamSecret() {
-    return iamSecret;
+  public String getClientSecret() {
+    return this.clientSecret;
   }
 
-  public static void setIamSecret(String iamSecret) {
-    IamTokenManager.iamSecret = iamSecret;
+  public void setClientSecret(String clientSecret) {
+    this.clientSecret = clientSecret;
   }
 
-  public static String getAuthorizationHeaderValue() {
+  public String getAuthorizationHeaderValue() {
     String result;
-    if (getIamClientId() != null && getIamSecret() != null) {
-      String s = getIamClientId() + ":" + getIamSecret();
+    if (getClientId() != null && getClientSecret() != null) {
+      String s = getClientId() + ":" + getClientSecret();
       result = "Basic " + Base64.getEncoder().encodeToString(s.getBytes());
     } else {
       result = DEFAULT_AUTHORIZATION;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/IamManagerTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/IamManagerTest.java
@@ -45,19 +45,29 @@ public class IamManagerTest extends BaseServiceUnitTest {
   @Test
   public void testAuthorizationHeader() {
     // Make sure the default header value is correct.
-    String header1 = IamTokenManager.getAuthorizationHeaderValue();
+    IamOptions options = new IamOptions.Builder()
+        .apiKey(API_KEY)
+        .url(url)
+        .build();
+    IamTokenManager manager = new IamTokenManager(options);
+    String header1 = manager.getAuthorizationHeaderValue();
     assertEquals(header1, "Basic Yng6Yng=");
 
     // Now make sure different clientid/secret combinations yield different header values
 
-    IamTokenManager.setIamClientId("myuser");
-    IamTokenManager.setIamSecret("mysecret");
-    String header2 = IamTokenManager.getAuthorizationHeaderValue();
+    manager.setClientId("myuser");
+    manager.setClientSecret("mysecret");
+    String header2 = manager.getAuthorizationHeaderValue();
     assertNotEquals(header1, header2);
 
-    IamTokenManager.setIamClientId("123j10iii38918-afde3");
-    IamTokenManager.setIamSecret("aU4RyzIZdFgZWxEroo1");
-    String header3 = IamTokenManager.getAuthorizationHeaderValue();
+    options = new IamOptions.Builder()
+        .apiKey(API_KEY)
+        .url(url)
+        .clientId("123j10iii38918-afde3")
+        .clientSecret("aU4RyzIZdFgZWxEroo1")
+        .build();
+    manager = new IamTokenManager(options);
+    String header3 = manager.getAuthorizationHeaderValue();
     assertNotEquals(header1, header3);
     assertNotEquals(header2, header3);
   }


### PR DESCRIPTION
This PR fixes the initial changes for issue https://github.ibm.com/arf/planning-sdk-squad/issues/851 :
1. The client id/secret can now be set via the IamOptions class.   This will allow SDK users to configure these values as part of instantiating the generated service object (i.e. the ctor accepts an IamOptions instance).
2. I changed "secret" to be "clientSecret" to be more descriptive and to align with "clientId".
3. The client id/secret values are no longer static.

The actual requirement is to allow SDK users to set the client id/secret values so that interactions with the IAM token server will use an Authorization header that reflects their specific id/secret rather than the default of "bx:bx".