### PR TITLE
feat: add de-serialization logic for JSON arrays within response body

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/util/ResponseConverterUtils.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/ResponseConverterUtils.java
@@ -65,8 +65,7 @@ public final class ResponseConverterUtils {
   }
 
   /**
-   * Creates a generic {@link ResponseConverter} for a POJO class. <br>
-   * It should extend {@link ObjectModel}
+   * Creates a generic {@link ResponseConverter} for a POJO class that extends ObjectModel.
    *
    * @param <T> the generic type
    * @param type the type
@@ -79,6 +78,17 @@ public final class ResponseConverterUtils {
         return ResponseUtils.getObject(response, type);
       }
     };
+  }
+
+  /**
+   * Creates a generic {@link ResponseConverter} for a POJO class.
+   *
+   * @param <T> the generic type
+   * @param type a Type instance that describes the type
+   * @return the response converter
+   */
+  public static <T> ResponseConverter<T> getObject(final Type type) {
+    return getValue(type);
   }
 
   /**
@@ -103,6 +113,23 @@ public final class ResponseConverterUtils {
    * @return the response converter
    */
   public static <T> ResponseConverter<T> getValue(final Class<? extends T> type) {
+    return new ResponseConverter<T>() {
+      @Override
+      public T convert(Response response) {
+        return ResponseUtils.getValue(response, type);
+      }
+    };
+  }
+
+  /**
+   * Creates a generic {@link ResponseConverter} for a response with a Type
+   * instance that describes the type.
+   * @param <T> the generic type
+   * @param type the type
+   *
+   * @return the response converter
+   */
+  public static <T> ResponseConverter<T> getValue(final Type type) {
     return new ResponseConverter<T>() {
       @Override
       public T convert(Response response) {

--- a/src/main/java/com/ibm/cloud/sdk/core/util/ResponseUtils.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/ResponseUtils.java
@@ -14,6 +14,7 @@ package com.ibm.cloud.sdk.core.util;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Type;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -96,6 +97,24 @@ public final class ResponseUtils {
     }
   }
 
+
+  /**
+   * Parses the {@link Response} into the POJO representation.
+   *
+   * @param <T> the generic type to use when parsing the response
+   * @param response the HTTP response
+   * @param type a Type instance which describes the type of the response
+   * @return the POJO
+   */
+  public static <T> T getObject(Response response, Type type) {
+    JsonReader reader;
+    try {
+      reader = new JsonReader(response.body().charStream());
+      return GsonSingleton.getGsonWithoutPrettyPrinting().fromJson(reader, type);
+    } finally {
+      response.body().close();
+    }
+  }
   /**
    * Parses the {@link Response} into a value of the specified type.
    *
@@ -105,6 +124,24 @@ public final class ResponseUtils {
    * @return the value
    */
   public static <T> T getValue(Response response, Class<? extends T> valueType) {
+    JsonReader reader;
+    try {
+      reader = new JsonReader(response.body().charStream());
+      return GsonSingleton.getGsonWithoutPrettyPrinting().fromJson(reader, valueType);
+    } finally {
+      response.body().close();
+    }
+  }
+
+  /**
+   * Parses the {@link Response} into a value of the specified type.
+   *
+   * @param <T> the generic type to use when parsing the response
+   * @param response the HTTP response
+   * @param valueType a Type instance which describes the type associated with the response
+   * @return the value
+   */
+  public static <T> T getValue(Response response, Type valueType) {
     JsonReader reader;
     try {
       reader = new JsonReader(response.body().charStream());


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/797 (for Java)

This PR adds the necessary function (and tests) to the Java SDK core to allow us to generate Java code that will support the de-serialization of a top-level (JSON) array within a response body.
With this change, the Java SDK core will support responses which contain an array of JSON object as well as primitive types.
Note that this PR will be a prereq to some related changes in the SDK generator.  That PR will be finished soon.