### PR TITLE
Fix generation on docs index page

### DIFF
--- a/build/push-javadoc-to-gh-pages.sh
+++ b/build/push-javadoc-to-gh-pages.sh
@@ -9,7 +9,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" ]; then
     rm -rf docs/$TRAVIS_BRANCH
     mkdir -p docs/$TRAVIS_BRANCH
     cp -rf ../target/site/apidocs/* docs/$TRAVIS_BRANCH
-    ../.build/generate-index-html.sh > index.html
+    ./../build/generate-index-html.sh > index.html
 
     git add -f .
     git commit -m "Latest javadoc for $TRAVIS_BRANCH ($TRAVIS_COMMIT)"


### PR DESCRIPTION
I promise this is the **last** tweak I'll need to make to get the docs generated automatically. They went out mostly fine on the last release except that the main `index.html` file was cleared because I called the script to generate it in the wrong location.

This PR solves that problem and I made sure to test locally, so we should be good now.