### PR TITLE
feat(http): improve SDK's ability to configure http client instances

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
@@ -103,6 +103,22 @@ public abstract class BaseService {
   }
 
   /**
+   * Returns the currently-configured {@link OkHttpClient} instance.
+   * @return the {@link OkHttpClient} instance
+   */
+  public OkHttpClient getClient() {
+    return client;
+  }
+
+  /**
+   * Sets a new {@link OkHttpClient} instance to be used for API invocations by this BaseService instance.
+   * @param client the new {@link OkHttpClient} instance
+   */
+  public void setClient(OkHttpClient client) {
+    this.client = client;
+  }
+
+  /**
    * Calls appropriate methods to set credential values based on parsed ServiceCredentials object.
    *
    * @param serviceCredentials object containing parsed credential values
@@ -156,12 +172,12 @@ public abstract class BaseService {
   }
 
   /**
-   * Configures the {@link OkHttpClient} based on the passed-in options.
+   * Configures the currently-configured {@link OkHttpClient} instance based on the passed-in options.
    *
    * @param options the {@link HttpConfigOptions} object for modifying the client
    */
   public void configureClient(HttpConfigOptions options) {
-    client = HttpClientSingleton.getInstance().configureClient(options);
+    this.client = HttpClientSingleton.getInstance().configureClient(this.client, options);
   }
 
   /**


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/859

This PR allows a Java SDK to be more easily modify the configuration of the `OkHttpClient` instance used by the Java core for REST API invocations.   With these changes, an SDK user would also have the ability to create and set their own `OkHttpClient` instance for use by the SDK (similar to the Go core).

The new tests added to the BaseServiceTest class should demonstrate the gist of these changes.