### PR TITLE
Added HTTP status code to response

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/http/Response.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/Response.java
@@ -22,11 +22,13 @@ public class Response<T> {
   private T result;
   private Headers headers;
   private int statusCode;
+  private String statusMessage;
 
   public Response(T result, okhttp3.Response httpResponse) {
     this.result = result;
     this.headers = new Headers(httpResponse.headers());
     this.statusCode = httpResponse.code();
+    this.statusMessage = httpResponse.message();
   }
 
   public T getResult() {
@@ -39,5 +41,9 @@ public class Response<T> {
 
   public int getStatusCode() {
     return this.statusCode;
+  }
+
+  public String getStatusMessage() {
+    return this.statusMessage;
   }
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/http/Response.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/Response.java
@@ -21,10 +21,12 @@ public class Response<T> {
 
   private T result;
   private Headers headers;
+  private int statusCode;
 
   public Response(T result, okhttp3.Response httpResponse) {
     this.result = result;
     this.headers = new Headers(httpResponse.headers());
+    this.statusCode = httpResponse.code();
   }
 
   public T getResult() {
@@ -33,5 +35,9 @@ public class Response<T> {
 
   public Headers getHeaders() {
     return this.headers;
+  }
+
+  public int getStatusCode() {
+    return this.statusCode;
   }
 }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/ResponseTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/ResponseTest.java
@@ -340,4 +340,14 @@ public class ResponseTest extends BaseServiceUnitTest {
     assertEquals("The response status code should be 204.", 204, response.getStatusCode());
   }
 
+  /**
+   * Test getting the status line message from a response.
+   */
+  @Test
+  public void testResponseMessage() {
+    server.enqueue(new MockResponse().setStatus("HTTP/1.1 204 No Content"));
+    Response<Void> response = service.headMethod().execute();
+    assertEquals("The response status message should be 'No Content'.", "No Content", response.getStatusMessage());
+  }
+
 }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/ResponseTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/ResponseTest.java
@@ -329,4 +329,15 @@ public class ResponseTest extends BaseServiceUnitTest {
     assertEquals(Arrays.asList("Austin", "Georgetown", "Cedar Park"), actualCities);
     assertNotNull(response.getHeaders());
   }
+
+  /**
+   * Test getting the status code from a response.
+   */
+  @Test
+  public void testResponseCode() {
+    server.enqueue(new MockResponse().setResponseCode(204));
+    Response<Void> response = service.headMethod().execute();
+    assertEquals("The response status code should be 204.", 204, response.getStatusCode());
+  }
+
 }


### PR DESCRIPTION
The `Response` class is usually only generated for a successful response (i.e. `200` <= status code < `400`), but there may still be useful information encapsulated in the successful status code. For example, when creating resources `201` and `202` convey different information about what has happened on the server (`Created` vs `Accepted`).

This PR adds a `com.ibm.cloud.sdk.core.http.Response#getStatusCode` method so that additional information of the status code can be accessed by the caller.

It adds a single test `com.ibm.cloud.sdk.core.test.service.ResponseTest#testResponseCode` to demonstrate that the code is set and retrievable.