### PR TITLE
feat(*): remove obsolete methods from BaseService

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/security/icp4d/ICP4DAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/icp4d/ICP4DAuthenticator.java
@@ -33,6 +33,7 @@ import java.util.logging.Logger;
 /**
  * This class implements support for the ICP4D authentication mechanism.
  */
+@SuppressWarnings("unused")
 public class ICP4DAuthenticator implements Authenticator {
   private static final Logger LOG = Logger.getLogger(ICP4DAuthenticator.class.getName());
 

--- a/src/main/java/com/ibm/cloud/sdk/core/security/icp4d/ICP4DConfig.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/icp4d/ICP4DConfig.java
@@ -40,13 +40,13 @@ public class ICP4DConfig implements AuthenticatorConfig {
 
   @Override
   public void validate() {
-    if (StringUtils.isEmpty(url)) {
-      throw new IllegalArgumentException("You must provide a URL.");
-    }
-
-    // If the user specifies their own access token, then username/password are not required.
+    // If the user specifies their own access token, then no other properties are required.
     if (StringUtils.isNotEmpty(userManagedAccessToken)) {
       return;
+    }
+
+    if (StringUtils.isEmpty(url)) {
+      throw new IllegalArgumentException("You must provide a URL.");
     }
 
     if (StringUtils.isEmpty(username) || StringUtils.isEmpty(password)) {

--- a/src/main/java/com/ibm/cloud/sdk/core/service/security/IamOptions.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/security/IamOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 IBM Corp. All Rights Reserved.
+ * Copyright 2018, 2019 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/AuthenticationTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/AuthenticationTest.java
@@ -16,6 +16,7 @@ import com.ibm.cloud.sdk.core.util.CredentialUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("deprecation")
@@ -105,6 +106,51 @@ public class AuthenticationTest {
     service.setSkipAuthentication(true);
     assertTrue(service.authenticator() instanceof NoauthAuthenticator);
     assertTrue(service.isSkipAuthentication());
+  }
+
+  @Test
+  public void testDefaultServiceCtor() {
+    TestService service = new TestService();
+    assertFalse(service.isSkipAuthentication());
+    assertNull(service.authenticator());
+  }
+
+  @Test
+  public void testSetAuthenticator() {
+    // Test use of setAuthenticator() on existing service instance.
+    TestService service = new TestService();
+    assertFalse(service.isSkipAuthentication());
+    assertNull(service.authenticator());
+
+    service.setAuthenticator(new NoauthConfig());
+    assertTrue(service.authenticator() instanceof NoauthAuthenticator);
+    assertTrue(service.isSkipAuthentication());
+
+    service.setAuthenticator(null);
+    assertNull(service.authenticator());
+    assertFalse(service.isSkipAuthentication());
+
+    BasicAuthConfig baConfig = new BasicAuthConfig.Builder()
+        .username("user")
+        .password("pw")
+        .build();
+    service.setAuthenticator(baConfig);
+    assertTrue(service.authenticator() instanceof BasicAuthenticator);
+    assertFalse(service.isSkipAuthentication());
+
+    IamOptions iamConfig = new IamOptions.Builder()
+        .apiKey("myapikey")
+        .build();
+    service.setAuthenticator(iamConfig);
+    assertTrue(service.authenticator() instanceof IamTokenManager);
+    assertFalse(service.isSkipAuthentication());
+
+    ICP4DConfig icp4dConfig = new ICP4DConfig.Builder()
+        .userManagedAccessToken("myuseraccesstoken")
+        .build();
+    service.setAuthenticator(icp4dConfig);
+    assertTrue(service.authenticator() instanceof ICP4DAuthenticator);
+    assertFalse(service.isSkipAuthentication());
   }
 
   @Test


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/904

BREAKING CHANGE:
This PR removes support for the standalone "apikey" authentication path
in the BaseService class, including the removal of "setApiKey()".
Going forward, authentication should be configured on a service instance
using generated service ctors or the BaseService.setAuthenticator() method.