### PR TITLE
feat(serialization): Allow dynamic models to have non-public default ctors

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/util/DynamicModelTypeAdapterFactory.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/DynamicModelTypeAdapterFactory.java
@@ -106,7 +106,7 @@ public class DynamicModelTypeAdapterFactory implements TypeAdapterFactory {
     Constructor<?> ctor = getDefaultCtor(rawType);
     if (ctor == null) {
       LOGGER.warning("Instance of class " + rawType.getName() + " is a subclass of DynamicModel, but it doesn't "
-        + "have a public default constructor.  This instance will be ignored by " + this.getClass().getSimpleName());
+        + "define a default constructor.  This instance will be ignored by " + this.getClass().getSimpleName());
       return null;
     }
 
@@ -121,10 +121,13 @@ public class DynamicModelTypeAdapterFactory implements TypeAdapterFactory {
    * @return clazz's default ctor
    */
   protected Constructor<?> getDefaultCtor(Class<?> clazz) {
-    Constructor<?>[] allCtors = clazz.getConstructors();
+    Constructor<?>[] allCtors = clazz.getDeclaredConstructors();
     for (int i = 0; i < allCtors.length; i++) {
       Constructor<?> ctor = allCtors[i];
       if (ctor.getParameterTypes().length == 0) {
+        if (!ctor.isAccessible()) {
+          accessor.makeAccessible(ctor);
+        }
         return ctor;
       }
     }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/DynamicModelSerializationTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/DynamicModelSerializationTest.java
@@ -23,6 +23,7 @@ import com.ibm.cloud.sdk.core.test.model.generated.ModelAPFooNoCtor;
 import com.ibm.cloud.sdk.core.test.model.generated.ModelAPFooNullTypeToken;
 import com.ibm.cloud.sdk.core.test.model.generated.ModelAPInteger;
 import com.ibm.cloud.sdk.core.test.model.generated.ModelAPObject;
+import com.ibm.cloud.sdk.core.test.model.generated.ModelAPProtectedCtor;
 import com.ibm.cloud.sdk.core.test.model.generated.ModelAPString;
 import com.ibm.cloud.sdk.core.util.GsonSingleton;
 import org.testng.annotations.Test;
@@ -123,6 +124,15 @@ public class DynamicModelSerializationTest {
 
   private ModelAPString createModelAPString() {
     ModelAPString model = new ModelAPString();
+    model.setProp1("value1");
+    model.setProp2(Long.valueOf(33));
+    model.put("baseball", "C");
+    model.put("football", "LT");
+    return model;
+  }
+
+  private ModelAPProtectedCtor createModelAPProtectedCtor() {
+    ModelAPProtectedCtor model = new ModelAPProtectedCtor("x");
     model.setProp1("value1");
     model.setProp2(Long.valueOf(33));
     model.put("baseball", "C");
@@ -259,6 +269,13 @@ public class DynamicModelSerializationTest {
     String jsonString = "null";
     ModelAPFoo model = deserialize(jsonString, ModelAPFoo.class);
     assertNull(model);
+  }
+
+  @Test
+  public void testModelAPProtectedCtor() {
+    ModelAPProtectedCtor model = createModelAPProtectedCtor();
+    // model.put("basketball", Integer.valueOf(33));
+    testSerDeser(model, ModelAPProtectedCtor.class, false);
   }
 
   @Test(expectedExceptions = {JsonSyntaxException.class}, expectedExceptionsMessageRegExp="Duplicate key: baseball")

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPProtectedCtor.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPProtectedCtor.java
@@ -17,16 +17,20 @@ import com.google.gson.reflect.TypeToken;
 import com.ibm.cloud.sdk.core.service.model.DynamicModel;
 
 /**
- * Model with additionalProperties set to ref to named schema.
+ * Model with additionalProperties set to a string schema.
  */
-public class ModelAPFooNoCtor extends DynamicModel<Foo> {
-  @SerializedName(value="prop1", alternate={"property1", "p1"})
+public class ModelAPProtectedCtor extends DynamicModel<String> {
+  @SerializedName("prop1")
   private String prop1;
-  @SerializedName(value="prop2", alternate={"property2", "p2"})
+  @SerializedName("prop2")
   private Long prop2;
 
-  public ModelAPFooNoCtor(String x) {
-    super(new TypeToken<Foo>(){});
+  protected ModelAPProtectedCtor() {
+    super(new TypeToken<String>(){});
+  }
+
+  public ModelAPProtectedCtor(String x) {
+    this();
   }
 
   /**


### PR DESCRIPTION
This PR will allow dynamic models (subclasses of DynamicModel<T>) to define a protected (or private) default ctor instead of a public one.   We need this to accommodate the code pattern used by our new oneOf/anyOf processing whereby the parent schema (the schema containing the oneOf/anyOf list) will define a protected default ctor to prevent users from instantiating it (they would have to use a base class instead).   For this reason, we need the DynamicModelTypeAdapterFactory class to recognize a non-public default ctor when checking to see if it should handle a specific class.