### PR TITLE
(v4) Allow for proxy auth configuration

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/http/HttpClientSingleton.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/HttpClientSingleton.java
@@ -15,6 +15,7 @@ package com.ibm.cloud.sdk.core.http;
 import com.ibm.cloud.sdk.core.service.BaseService;
 import com.ibm.cloud.sdk.core.service.security.DelegatingSSLSocketFactory;
 import com.ibm.cloud.sdk.core.util.HttpLogging;
+import okhttp3.Authenticator;
 import okhttp3.ConnectionSpec;
 import okhttp3.OkHttpClient;
 import okhttp3.OkHttpClient.Builder;
@@ -177,6 +178,19 @@ public class HttpClientSingleton {
   }
 
   /**
+   * Sets a proxy authenticator for the specified {@link OkHttpClient} instance and returns
+   * a new instance with the authentication configured as requested.
+   *
+   * @param client the {@link OkHttpClient} instance to set the proxy authenticator on
+   * @param proxyAuthenticator the {@link Authenticator}
+   * @return the new {@link OkHttpClient} instance with the authenticator configured
+   */
+  private OkHttpClient setProxyAuthenticator(OkHttpClient client, Authenticator proxyAuthenticator) {
+    OkHttpClient.Builder builder = client.newBuilder().proxyAuthenticator(proxyAuthenticator);
+    return builder.build();
+  }
+
+  /**
    * Specifically enable all TLS protocols. See: https://github.com/watson-developer-cloud/java-sdk/issues/610
    *
    * @param builder the {@link OkHttpClient} builder.
@@ -259,7 +273,11 @@ public class HttpClientSingleton {
       if (options.getProxy() != null) {
         client = setProxy(client, options.getProxy());
       }
+      if (options.getProxyAuthenticator() != null) {
+        client = setProxyAuthenticator(client, options.getProxyAuthenticator());
+      }
     }
     return client;
   }
+
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/http/HttpConfigOptions.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/HttpConfigOptions.java
@@ -1,5 +1,7 @@
 package com.ibm.cloud.sdk.core.http;
 
+import okhttp3.Authenticator;
+
 import java.net.Proxy;
 
 /**
@@ -8,6 +10,7 @@ import java.net.Proxy;
 public class HttpConfigOptions {
   private boolean disableSslVerification;
   private Proxy proxy;
+  private Authenticator proxyAuthenticator;
 
   public boolean shouldDisableSslVerification() {
     return this.disableSslVerification;
@@ -17,9 +20,14 @@ public class HttpConfigOptions {
     return this.proxy;
   }
 
+  public Authenticator getProxyAuthenticator() {
+    return this.proxyAuthenticator;
+  }
+
   public static class Builder {
     private boolean disableSslVerification;
     private Proxy proxy;
+    private Authenticator proxyAuthenticator;
 
     public HttpConfigOptions build() {
       return new HttpConfigOptions(this);
@@ -47,10 +55,23 @@ public class HttpConfigOptions {
       this.proxy = proxy;
       return this;
     }
+
+    /**
+     * Sets HTTP proxy authentication to be used by connections with the current client.
+     *
+     * @param proxyAuthenticator the desired {@link Authenticator}
+     * @return the builder
+     */
+    public Builder proxyAuthenticator(Authenticator proxyAuthenticator) {
+      this.proxyAuthenticator = proxyAuthenticator;
+      return this;
+    }
+
   }
 
   private HttpConfigOptions(Builder builder) {
     this.disableSslVerification = builder.disableSslVerification;
     this.proxy = builder.proxy;
+    this.proxyAuthenticator = builder.proxyAuthenticator;
   }
 }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/http/HttpConfigTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/http/HttpConfigTest.java
@@ -1,9 +1,15 @@
 package com.ibm.cloud.sdk.core.test.http;
 
+import okhttp3.Authenticator;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Route;
 import org.junit.Test;
 
 import com.ibm.cloud.sdk.core.http.HttpConfigOptions;
 
+import javax.annotation.Nullable;
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 
@@ -16,13 +22,23 @@ public class HttpConfigTest {
 
   @Test
   public void testHttpConfigOptions() {
+    Authenticator authenticator = new Authenticator() {
+      @Nullable
+      @Override
+      public Request authenticate(@Nullable Route route, Response response) throws IOException {
+        return null;
+      }
+    };
+
     Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("proxyHost", 8080));
     HttpConfigOptions configOptions = new HttpConfigOptions.Builder()
         .disableSslVerification(true)
         .proxy(proxy)
+            .proxyAuthenticator(authenticator)
         .build();
 
     assertEquals(true, configOptions.shouldDisableSslVerification());
+    assertEquals(authenticator, configOptions.getProxyAuthenticator());
     assertEquals(proxy, configOptions.getProxy());
   }
 }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/http/HttpConfigTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/http/HttpConfigTest.java
@@ -34,7 +34,7 @@ public class HttpConfigTest {
     HttpConfigOptions configOptions = new HttpConfigOptions.Builder()
         .disableSslVerification(true)
         .proxy(proxy)
-            .proxyAuthenticator(authenticator)
+        .proxyAuthenticator(authenticator)
         .build();
 
     assertEquals(true, configOptions.shouldDisableSslVerification());


### PR DESCRIPTION
This PR contains the same changes introduced [here](https://github.com/IBM/java-sdk-core/pull/45), just for version `4.x.x`, since I plan to incorporate this change into the Watson Java SDK.