### PR TITLE
feat(serialization): added gson type adapter for byte[]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <logback-version>1.2.3</logback-version>
         <guava-version>27.1-android</guava-version>
         <gson-version>2.8.5</gson-version>
+        <commons-codec-version>1.12</commons-codec-version>
         <commons-io-version>2.6</commons-io-version>
         <commons-lang3-version>3.8.1</commons-lang3-version>
         <rx-version>2.2.7</rx-version>
@@ -80,6 +81,11 @@
             <artifactId>mockwebserver</artifactId>
             <version>${okhttp3-version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec-version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/java/com/ibm/cloud/sdk/core/util/ByteArrayTypeAdapter.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/ByteArrayTypeAdapter.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2019 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.sdk.core.util;
+
+import java.io.IOException;
+
+import org.apache.commons.codec.binary.Base64;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * This class serves as a GSON type adapter for the "byte[]" type.
+ * Values of type byte[] will be serialized into a string of base64-encoded characters.
+ */
+public class ByteArrayTypeAdapter extends TypeAdapter<byte[]> {
+
+  @Override
+  public void write(JsonWriter out, byte[] value) throws IOException {
+    out.value(Base64.encodeBase64String(value));
+  }
+
+  @Override
+  public byte[] read(JsonReader in) throws IOException {
+    return Base64.decodeBase64(in.nextString());
+  }
+}

--- a/src/main/java/com/ibm/cloud/sdk/core/util/GsonSingleton.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/GsonSingleton.java
@@ -52,6 +52,7 @@ public final class GsonSingleton {
     // Date serializer and deserializer
     builder.registerTypeAdapter(Date.class, new DateDeserializer());
     builder.registerTypeAdapter(Date.class, new DateSerializer());
+    builder.registerTypeAdapter(byte[].class, new ByteArrayTypeAdapter());
 
     // Type adapter factory for DynamicModel subclasses.
     builder.registerTypeAdapterFactory(new DynamicModelTypeAdapterFactory());

--- a/src/test/java/com/ibm/cloud/sdk/core/test/util/ByteArrayTypeAdapterTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/util/ByteArrayTypeAdapterTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2019 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.sdk.core.test.util;
+
+import static org.testng.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+import com.ibm.cloud.sdk.core.util.GsonSingleton;
+
+/**
+ *
+ */
+public class ByteArrayTypeAdapterTest {
+  private boolean displayOutput = false;
+
+  private String serialize(Object obj) {
+    return GsonSingleton.getGson().toJson(obj);
+  }
+
+  private <T> T deserialize(String json, Class<T> clazz) {
+    return GsonSingleton.getGson().fromJson(json, clazz);
+  }
+
+  private <T> void testSerDeser(T model, Class<T> clazz) {
+    String jsonString = serialize(model);
+    if (displayOutput) {
+      System.out.println("serialized " + model.getClass().getSimpleName() + ": " + jsonString);
+    }
+    T newModel = deserialize(jsonString, clazz);
+    if (displayOutput) {
+      System.out.println("de-serialized " + model.getClass().getSimpleName() + ": " + newModel.toString());
+    }
+    assertEquals(newModel, model);
+  }
+
+  public class Model1 extends GenericModel {
+    public String name;
+    public byte[] bytes;
+
+    public Model1(String name, byte[] bytes) {
+      this.name = name;
+      this.bytes = bytes;
+    }
+  }
+
+  @Test
+  public void testByteArray1() {
+    Model1 model1 = new Model1("name1", new byte[] {01, 02, 03, 04, 05});
+
+    testSerDeser(model1, Model1.class);
+  }
+
+  @Test
+  public void testByteArray2() {
+    String bytes = "This is a test of the emergency broadast system. This is only a test.";
+    Model1 model1 = new Model1("name2", bytes.getBytes());
+
+    testSerDeser(model1, Model1.class);
+  }
+}


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/908

This PR introduces a Gson Type Adapter for "byte []" values.
This will ensure that any model class fields of type "byte[]" are serialized and deserialized properly.
In the case of "byte[]" this means that the sequence of bytes is transformed into a string of base64-encoded characters.   On the deserialization side, we would transform the string of base64-encoded characters found in the JSON instance by decoding them into their original byte values and store in the resulting byte[].