### PR TITLE
feat(serialization): Avoid ser/deser roundtripping asymmetry for Object map value type

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/util/GsonSingleton.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/GsonSingleton.java
@@ -16,6 +16,8 @@ import java.util.Date;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.internal.LazilyParsedNumber;
+import com.google.gson.internal.bind.TypeAdapters;
 
 /**
  * Gson singleton to be use when transforming from JSON to Java Objects and vise versa. It handles date formatting and
@@ -52,7 +54,12 @@ public final class GsonSingleton {
     // Date serializer and deserializer
     builder.registerTypeAdapter(Date.class, new DateDeserializer());
     builder.registerTypeAdapter(Date.class, new DateSerializer());
+
+    // Make sure that byte[] ser/deser includes base64 encoding/decoding.
     builder.registerTypeAdapter(byte[].class, new ByteArrayTypeAdapter());
+
+    // Make sure we serialize LazilyParsedNumber properly to avoid unnecessary decimal places in serialized integers.
+    builder.registerTypeAdapter(LazilyParsedNumber.class, TypeAdapters.NUMBER);
 
     // Type adapter factory for DynamicModel subclasses.
     builder.registerTypeAdapterFactory(new DynamicModelTypeAdapterFactory());

--- a/src/main/java/com/ibm/cloud/sdk/core/util/MapValueObjectTypeAdapter.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/MapValueObjectTypeAdapter.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2019 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+/*
+ * Copyright (C) 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ibm.cloud.sdk.core.util;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.internal.LazilyParsedNumber;
+import com.google.gson.internal.LinkedTreeMap;
+import com.google.gson.internal.bind.ObjectTypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * This class is adapted from the ObjectTypeAdapter from the GSON project.
+ * When de-serializing a dynamic model, when we encounter an arbitrary property that is an object,
+ * we'll use this type adapter instead of GSON's ObjectTypeAdapter.
+ * This will ensure that the LazilyParsedNumber class is used to represent JSON number fields within
+ * the object instead of Double.
+ *
+ * Adapts types whose static type is only 'Object'. Uses getClass() on
+ * serialization and a primitive/Map/List on deserialization.
+ */
+public final class MapValueObjectTypeAdapter extends TypeAdapter<Object> {
+  private final Gson gson;
+
+  MapValueObjectTypeAdapter(Gson gson) {
+    this.gson = gson;
+  }
+
+  @Override public Object read(JsonReader in) throws IOException {
+    JsonToken token = in.peek();
+    switch (token) {
+    case BEGIN_ARRAY:
+      List<Object> list = new ArrayList<Object>();
+      in.beginArray();
+      while (in.hasNext()) {
+        list.add(read(in));
+      }
+      in.endArray();
+      return list;
+
+    case BEGIN_OBJECT:
+      Map<String, Object> map = new LinkedTreeMap<String, Object>();
+      in.beginObject();
+      while (in.hasNext()) {
+        map.put(in.nextName(), read(in));
+      }
+      in.endObject();
+      return map;
+
+    case STRING:
+      return in.nextString();
+
+    case NUMBER:
+      // Use LazilyParsedNumber instead of Double for a JSON number value.
+      return new LazilyParsedNumber(in.nextString());
+
+    case BOOLEAN:
+      return in.nextBoolean();
+
+    case NULL:
+      in.nextNull();
+      return null;
+
+    default:
+      throw new IllegalStateException();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override public void write(JsonWriter out, Object value) throws IOException {
+    if (value == null) {
+      out.nullValue();
+      return;
+    }
+
+    TypeAdapter<Object> typeAdapter = (TypeAdapter<Object>) gson.getAdapter(value.getClass());
+    if (typeAdapter instanceof ObjectTypeAdapter) {
+      out.beginObject();
+      out.endObject();
+      return;
+    }
+
+    typeAdapter.write(out, value);
+  }
+}

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/DynamicModelSerializationTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/DynamicModelSerializationTest.java
@@ -52,7 +52,7 @@ public class DynamicModelSerializationTest {
     return GsonSingleton.getGson().fromJson(json, clazz);
   }
 
-  private <T> void testSerDeser(DynamicModel<?> model, Class<T> clazz, boolean trimDecimals) {
+  private <T> void testSerDeser(DynamicModel<?> model, Class<T> clazz) {
     String jsonString = serialize(model);
     if (displayOutput) {
       System.out.println("serialized " + model.getClass().getSimpleName() + ": " + jsonString);
@@ -61,12 +61,7 @@ public class DynamicModelSerializationTest {
     if (displayOutput) {
       System.out.println("de-serialized " + model.getClass().getSimpleName() + ": " + newModel.toString());
     }
-    if (trimDecimals) {
-      String deserString = newModel.toString().replaceAll(".0", "");
-      assertEquals(deserString, jsonString);
-    } else {
-      assertEquals(newModel, model);
-    }
+    assertEquals(newModel, model);
   }
 
   private ModelAPFoo createModelAPFoo() {
@@ -164,7 +159,7 @@ public class DynamicModelSerializationTest {
   public void testModelAPFoo() {
     ModelAPFoo model = createModelAPFoo();
     // model.put("basketball", "foo");
-    testSerDeser(model, ModelAPFoo.class, false);
+    testSerDeser(model, ModelAPFoo.class);
   }
 
   @Test
@@ -207,7 +202,7 @@ public class DynamicModelSerializationTest {
     ModelAPFoo model = createModelAPFoo();
     model.setProp1(null);
     // model.put("basketball", "foo");
-    testSerDeser(model, ModelAPFoo.class, false);
+    testSerDeser(model, ModelAPFoo.class);
   }
 
   @Test(expectedExceptions = {JsonSyntaxException.class})
@@ -242,26 +237,26 @@ public class DynamicModelSerializationTest {
   public void testModelAPInteger() {
     ModelAPInteger model = createModelAPInteger();
     // model.put("basketball", "foo");
-    testSerDeser(model, ModelAPInteger.class, false);
+    testSerDeser(model, ModelAPInteger.class);
   }
 
   @Test
   public void testModelAPObject() {
     ModelAPObject model = createModelAPObject();
-    testSerDeser(model, ModelAPObject.class, true);
+    testSerDeser(model, ModelAPObject.class);
   }
 
   @Test
   public void testModelAPString() {
     ModelAPString model = createModelAPString();
     // model.put("basketball", Integer.valueOf(33));
-    testSerDeser(model, ModelAPString.class, false);
+    testSerDeser(model, ModelAPString.class);
   }
 
   @Test
   public void testModelAPFooNullTypeToken() {
     ModelAPFooNullTypeToken model = createModelAPFooNullTypeToken();
-    testSerDeser(model, ModelAPFooNullTypeToken.class, true);
+    testSerDeser(model, ModelAPFooNullTypeToken.class);
   }
 
   @Test
@@ -275,7 +270,7 @@ public class DynamicModelSerializationTest {
   public void testModelAPProtectedCtor() {
     ModelAPProtectedCtor model = createModelAPProtectedCtor();
     // model.put("basketball", Integer.valueOf(33));
-    testSerDeser(model, ModelAPProtectedCtor.class, false);
+    testSerDeser(model, ModelAPProtectedCtor.class);
   }
 
   @Test(expectedExceptions = {JsonSyntaxException.class}, expectedExceptionsMessageRegExp="Duplicate key: baseball")


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/951

This PR introduces changes to avoid ser/deser asymmetry problems when dealing with 
DynamicModels with "Object" as the map value type.
Summary of changes:
1) Introduced new "MapValueObjectTypeAdapter" which will be used specifically for map values when
the map value type is Object.   This is an adaptation of Gson's ObjectTypeAdapter, with the main change being that a JSON number will be deserialized into an instance of Gson's LazilyParseNumber instead of java.lang.Double.
2) DynamicModelTypeAdapterFactory was changed to use MapValueObjectTypeAdapter when the map value type is Object.
3) The relevant testcase was modified to NOT compensate for the unnecessary decimal points when serializing a previously deserialized object, since the decimal points will no longer be included in the JSON string.