### PR TITLE
fix: do not use 'serializeNulls' when initializing Gson

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/http/RequestBuilder.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/RequestBuilder.java
@@ -334,7 +334,7 @@ public class RequestBuilder {
   public RequestBuilder bodyContent(String contentType, Object jsonContent, Object jsonPatchContent,
     InputStream nonJsonContent) {
     if (contentType != null) {
-      Gson requestGson = GsonSingleton.getGson().newBuilder().serializeNulls().create();
+      Gson requestGson = GsonSingleton.getGson().newBuilder().create();
       if (BaseService.isJsonMimeType(contentType)) {
         this.bodyContent(requestGson.toJsonTree(jsonContent).getAsJsonObject().toString(), contentType);
       } else if (BaseService.isJsonPatchMimeType(contentType)) {


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/960

This PR removes the call to `serializeNulls()` when creating a `Gson` instance while serializing JSON content inside `RequestBuilder.bodyContent(String, Object, Object, InputStream)`.
This will ensure that we're serializing JSON body content in the same way no matter whether the operation accepts only JSON content, or JSON content in addition to other types as well.