### PR TITLE
fix: perform correct transformation on serviceName; use case-insensitive auth type comparisons

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/http/Headers.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/Headers.java
@@ -1,3 +1,16 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package com.ibm.cloud.sdk.core.http;
 
 import java.util.List;
@@ -20,14 +33,17 @@ public class Headers {
    * @param other the other object to compare
    * @return whether the two objects are equal or not
    */
+  @Override
   public boolean equals(Object other) {
     return this.headers.equals(other);
   }
 
+  @Override
   public int hashCode() {
     return this.headers.hashCode();
   }
 
+  @Override
   public String toString() {
     return this.headers.toString();
   }

--- a/src/main/java/com/ibm/cloud/sdk/core/http/HttpClientSingleton.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/HttpClientSingleton.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.http;
 
 import com.ibm.cloud.sdk.core.http.HttpConfigOptions.LoggingLevel;

--- a/src/main/java/com/ibm/cloud/sdk/core/http/HttpConfigOptions.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/HttpConfigOptions.java
@@ -1,3 +1,16 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package com.ibm.cloud.sdk.core.http;
 
 import okhttp3.Authenticator;

--- a/src/main/java/com/ibm/cloud/sdk/core/http/HttpHeaders.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/HttpHeaders.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.http;
 
 /**

--- a/src/main/java/com/ibm/cloud/sdk/core/http/HttpMediaType.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/HttpMediaType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.http;
 
 import okhttp3.MediaType;

--- a/src/main/java/com/ibm/cloud/sdk/core/http/HttpStatus.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/HttpStatus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.http;
 
 /**

--- a/src/main/java/com/ibm/cloud/sdk/core/http/InputStreamRequestBody.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/InputStreamRequestBody.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.http;
 
 import okhttp3.MediaType;

--- a/src/main/java/com/ibm/cloud/sdk/core/http/NameValue.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/NameValue.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.http;
 
 import com.ibm.cloud.sdk.core.util.Validator;

--- a/src/main/java/com/ibm/cloud/sdk/core/http/RequestBuilder.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/RequestBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.http;
 
 import com.google.gson.Gson;

--- a/src/main/java/com/ibm/cloud/sdk/core/http/Response.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/Response.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.http;
 
 /**

--- a/src/main/java/com/ibm/cloud/sdk/core/http/ResponseConverter.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/ResponseConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.http;
 
 import okhttp3.Response;

--- a/src/main/java/com/ibm/cloud/sdk/core/http/ServiceCall.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/ServiceCall.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.http;
 
 import io.reactivex.Single;

--- a/src/main/java/com/ibm/cloud/sdk/core/http/ServiceCallback.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/ServiceCallback.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.http;
 
 /**

--- a/src/main/java/com/ibm/cloud/sdk/core/http/ServiceCookieJar.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/ServiceCookieJar.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.http;
 
 import okhttp3.Cookie;

--- a/src/main/java/com/ibm/cloud/sdk/core/security/AbstractToken.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/AbstractToken.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.security;
 
 /**

--- a/src/main/java/com/ibm/cloud/sdk/core/security/Authenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/Authenticator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.security;
 
 import okhttp3.Request.Builder;

--- a/src/main/java/com/ibm/cloud/sdk/core/security/AuthenticatorBase.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/AuthenticatorBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.security;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/com/ibm/cloud/sdk/core/security/BasicAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/BasicAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.security;
 
 import java.util.Map;

--- a/src/main/java/com/ibm/cloud/sdk/core/security/BearerTokenAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/BearerTokenAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.security;
 
 import java.util.Map;

--- a/src/main/java/com/ibm/cloud/sdk/core/security/CloudPakForDataAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/CloudPakForDataAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.security;
 
 import java.util.Map;

--- a/src/main/java/com/ibm/cloud/sdk/core/security/ConfigBasedAuthenticatorFactory.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/ConfigBasedAuthenticatorFactory.java
@@ -23,6 +23,7 @@ import com.ibm.cloud.sdk.core.util.CredentialUtils;
  * It will detect and use various configuration sources in order to produce an Authenticator instance.
  */
 public class ConfigBasedAuthenticatorFactory {
+  public static final String ERRORMSG_AUTHTYPE_UNKNOWN = "Unrecognized authentication type: %s";
 
   // The default ctor is hidden since this is a utility class.
   protected ConfigBasedAuthenticatorFactory() {
@@ -65,28 +66,19 @@ public class ConfigBasedAuthenticatorFactory {
       authType = Authenticator.AUTHTYPE_IAM;
     }
 
-    switch (authType) {
-      case Authenticator.AUTHTYPE_NOAUTH:
-        authenticator = new NoAuthAuthenticator(props);
-        break;
-
-      case Authenticator.AUTHTYPE_BASIC:
-        authenticator = new BasicAuthenticator(props);
-        break;
-
-      case Authenticator.AUTHTYPE_IAM:
-        authenticator = new IamAuthenticator(props);
-        break;
-
-      case Authenticator.AUTHTYPE_CP4D:
-        authenticator = new CloudPakForDataAuthenticator(props);
-        break;
-
-      case Authenticator.AUTHTYPE_BEARER_TOKEN:
-        authenticator = new BearerTokenAuthenticator(props);
-        break;
-      default:
-        break;
+    // Create the appropriate authenticator based on the auth type.
+    if (authType.equalsIgnoreCase(Authenticator.AUTHTYPE_BASIC)) {
+      authenticator = new BasicAuthenticator(props);
+    } else if (authType.equalsIgnoreCase(Authenticator.AUTHTYPE_BEARER_TOKEN)) {
+      authenticator = new BearerTokenAuthenticator(props);
+    } else if (authType.equalsIgnoreCase(Authenticator.AUTHTYPE_CP4D)) {
+      authenticator = new CloudPakForDataAuthenticator(props);
+    } else if (authType.equalsIgnoreCase(Authenticator.AUTHTYPE_IAM)) {
+      authenticator = new IamAuthenticator(props);
+    } else if (authType.equalsIgnoreCase(Authenticator.AUTHTYPE_NOAUTH)) {
+      authenticator = new NoAuthAuthenticator(props);
+    } else {
+      throw new IllegalArgumentException(String.format(ERRORMSG_AUTHTYPE_UNKNOWN, authType));
     }
 
     return authenticator;

--- a/src/main/java/com/ibm/cloud/sdk/core/security/ConfigBasedAuthenticatorFactory.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/ConfigBasedAuthenticatorFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.security;
 
 import java.util.Map;

--- a/src/main/java/com/ibm/cloud/sdk/core/security/Cp4dToken.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/Cp4dToken.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.security;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/com/ibm/cloud/sdk/core/security/Cp4dTokenResponse.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/Cp4dTokenResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.security;
 
 /**

--- a/src/main/java/com/ibm/cloud/sdk/core/security/IamAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/IamAuthenticator.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2018 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.security;
 
 import java.util.Map;

--- a/src/main/java/com/ibm/cloud/sdk/core/security/IamToken.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/IamToken.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2018 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.security;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/com/ibm/cloud/sdk/core/security/JsonWebToken.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/JsonWebToken.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.security;
 
 import com.google.common.io.BaseEncoding;

--- a/src/main/java/com/ibm/cloud/sdk/core/security/NoAuthAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/NoAuthAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.security;
 
 import java.util.Map;

--- a/src/main/java/com/ibm/cloud/sdk/core/security/TokenRequestBasedAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/TokenRequestBasedAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.security;
 
 import java.net.Proxy;

--- a/src/main/java/com/ibm/cloud/sdk/core/security/TokenServerResponse.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/TokenServerResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.security;
 
 /**

--- a/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2017, 2019 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.service;
 
 import java.io.IOException;

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/BadRequestException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/BadRequestException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.service.exception;
 
 import com.ibm.cloud.sdk.core.http.HttpStatus;

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/ConflictException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/ConflictException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.service.exception;
 
 import com.ibm.cloud.sdk.core.http.HttpStatus;

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/ForbiddenException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/ForbiddenException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.service.exception;
 
 import com.ibm.cloud.sdk.core.http.HttpStatus;

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/InternalServerErrorException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/InternalServerErrorException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.service.exception;
 
 import com.ibm.cloud.sdk.core.http.HttpStatus;

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/NotFoundException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/NotFoundException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.service.exception;
 
 import com.ibm.cloud.sdk.core.http.HttpStatus;

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/RequestTooLargeException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/RequestTooLargeException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.service.exception;
 
 import com.ibm.cloud.sdk.core.http.HttpStatus;

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceResponseException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceResponseException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.service.exception;
 
 import com.google.gson.JsonObject;
@@ -90,6 +91,7 @@ public class ServiceResponseException extends RuntimeException {
    *
    * @return the error message
    */
+  @Override
   public String getMessage() {
     return message;
   }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceUnavailableException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/ServiceUnavailableException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.service.exception;
 
 import com.ibm.cloud.sdk.core.http.HttpStatus;

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/TooManyRequestsException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/TooManyRequestsException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.service.exception;
 
 import okhttp3.Response;

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/UnauthorizedException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/UnauthorizedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.service.exception;
 
 import com.ibm.cloud.sdk.core.http.HttpStatus;

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/UnsupportedException.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/UnsupportedException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.service.exception;
 
 import com.ibm.cloud.sdk.core.http.HttpStatus;

--- a/src/main/java/com/ibm/cloud/sdk/core/service/exception/package-info.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/exception/package-info.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/src/main/java/com/ibm/cloud/sdk/core/service/model/DynamicModel.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/model/DynamicModel.java
@@ -1,3 +1,16 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package com.ibm.cloud.sdk.core.service.model;
 
 import java.util.HashMap;

--- a/src/main/java/com/ibm/cloud/sdk/core/service/model/GenericModel.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/model/GenericModel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.service.model;
 
 import com.ibm.cloud.sdk.core.util.GsonSingleton;

--- a/src/main/java/com/ibm/cloud/sdk/core/service/model/ObjectModel.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/model/ObjectModel.java
@@ -1,3 +1,16 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package com.ibm.cloud.sdk.core.service.model;
 
 /**

--- a/src/main/java/com/ibm/cloud/sdk/core/service/security/DelegatingSSLSocketFactory.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/security/DelegatingSSLSocketFactory.java
@@ -1,18 +1,16 @@
-/*
- * Copyright (C) 2014 Square, Inc.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.service.security;
 
 import java.io.IOException;

--- a/src/main/java/com/ibm/cloud/sdk/core/util/BooleanToStringTypeAdapter.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/BooleanToStringTypeAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/src/main/java/com/ibm/cloud/sdk/core/util/ByteArrayTypeAdapter.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/ByteArrayTypeAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import java.io.IOException;

--- a/src/main/java/com/ibm/cloud/sdk/core/util/CredentialUtils.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/CredentialUtils.java
@@ -165,8 +165,7 @@ public final class CredentialUtils {
   }
 
   /**
-   * Returns the value associated with the provided key from the VCAP_SERVICES, or null if it doesn't exist. In the
-   * case of the API URL, if VCAP_SERVICES aren't present, this method will also search in JNDI.
+   * Returns the value associated with the provided key from the VCAP_SERVICES, or null if it doesn't exist.
    *
    * @param serviceName the service name
    * @param key the key whose value should be returned

--- a/src/main/java/com/ibm/cloud/sdk/core/util/CredentialUtils.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/CredentialUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import java.io.File;

--- a/src/main/java/com/ibm/cloud/sdk/core/util/CredentialUtils.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/CredentialUtils.java
@@ -258,13 +258,13 @@ public final class CredentialUtils {
     // Extract the properties related to the specified service and populate the result Map.
     if (env != null && !env.isEmpty()) {
       Map<String, String> props = new HashMap<>();
-      serviceName = serviceName.toUpperCase();
+      serviceName = serviceName.toUpperCase().replaceAll("-", "_") + "_";
       for (Map.Entry<String, String> entry : env.entrySet()) {
         String key = entry.getKey();
         String value = entry.getValue();
 
-        if (key.startsWith(serviceName + "_")) {
-          String credentialName = key.substring(serviceName.length() + 1);
+        if (key.startsWith(serviceName)) {
+          String credentialName = key.substring(serviceName.length());
           if (StringUtils.isNotEmpty(credentialName) && StringUtils.isNotEmpty(value)) {
             props.put(credentialName, value);
           }
@@ -347,7 +347,7 @@ public final class CredentialUtils {
   protected static Map<String, String> parseCredentials(String serviceName, List<String> contents) {
     Map<String, String> props = new HashMap<>();
 
-    serviceName = serviceName.toUpperCase();
+    serviceName = serviceName.toUpperCase().replaceAll("-", "_") + "_";
 
     // Within "contents", we're looking for lines of the form:
     //    <serviceName>_<credentialName>=<value>
@@ -368,8 +368,8 @@ public final class CredentialUtils {
       String key = lineTokens[0];
       String value = lineTokens[1];
 
-      if (key.startsWith(serviceName + "_")) {
-        String credentialName = key.substring(serviceName.length() + 1);
+      if (key.startsWith(serviceName)) {
+        String credentialName = key.substring(serviceName.length());
         if (StringUtils.isNotEmpty(credentialName) && StringUtils.isNotEmpty(value)) {
           props.put(credentialName, value);
         }

--- a/src/main/java/com/ibm/cloud/sdk/core/util/DateDeserializer.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/DateDeserializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import java.lang.reflect.Type;

--- a/src/main/java/com/ibm/cloud/sdk/core/util/DateSerializer.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/DateSerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import java.lang.reflect.Type;

--- a/src/main/java/com/ibm/cloud/sdk/core/util/DynamicModelTypeAdapterFactory.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/DynamicModelTypeAdapterFactory.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2019.
+ * Copyright (C) 2011 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -9,22 +10,6 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- */
-
-/*
- * Copyright (C) 2011 Google Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
 package com.ibm.cloud.sdk.core.util;

--- a/src/main/java/com/ibm/cloud/sdk/core/util/EnvironmentUtils.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/EnvironmentUtils.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ /**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,7 +10,8 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.ibm.cloud.sdk.core.util;
+
+ package com.ibm.cloud.sdk.core.util;
 
 import java.util.Map;
 

--- a/src/main/java/com/ibm/cloud/sdk/core/util/GsonSerializationHelper.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/GsonSerializationHelper.java
@@ -1,3 +1,16 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package com.ibm.cloud.sdk.core.util;
 
 import java.lang.reflect.Type;

--- a/src/main/java/com/ibm/cloud/sdk/core/util/GsonSingleton.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/GsonSingleton.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import java.util.Date;

--- a/src/main/java/com/ibm/cloud/sdk/core/util/HttpLogging.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/HttpLogging.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import java.util.logging.Logger;

--- a/src/main/java/com/ibm/cloud/sdk/core/util/LongToDateTypeAdapter.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/LongToDateTypeAdapter.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import java.io.IOException;

--- a/src/main/java/com/ibm/cloud/sdk/core/util/MapValueObjectTypeAdapter.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/MapValueObjectTypeAdapter.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2019.
+ * Copyright (C) 2011 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -9,22 +10,6 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- */
-
-/*
- * Copyright (C) 2011 Google Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
 package com.ibm.cloud.sdk.core.util;

--- a/src/main/java/com/ibm/cloud/sdk/core/util/RequestUtils.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/RequestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import com.ibm.cloud.sdk.core.http.HttpMediaType;

--- a/src/main/java/com/ibm/cloud/sdk/core/util/ResponseConverterUtils.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/ResponseConverterUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import java.io.InputStream;

--- a/src/main/java/com/ibm/cloud/sdk/core/util/ResponseUtils.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/ResponseUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import java.io.IOException;

--- a/src/main/java/com/ibm/cloud/sdk/core/util/StringHelper.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/StringHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/src/main/java/com/ibm/cloud/sdk/core/util/TypeAdapterRuntimeTypeWrapper.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/TypeAdapterRuntimeTypeWrapper.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
+ * Copyright (C) 2011 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,21 +12,6 @@
  * specific language governing permissions and limitations under the License.
  */
 
-/*
- * Copyright (C) 2011 Google Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.ibm.cloud.sdk.core.util;
 
 import java.io.IOException;

--- a/src/main/java/com/ibm/cloud/sdk/core/util/Validator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/Validator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import java.util.Collection;

--- a/src/main/java/com/ibm/cloud/sdk/core/util/package-info.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/package-info.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 /**
  * Utility classes to detect media types and convert files into input streams.
  */

--- a/src/test/java/com/ibm/cloud/sdk/core/test/BaseServiceUnitTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/BaseServiceUnitTest.java
@@ -1,3 +1,16 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package com.ibm.cloud.sdk.core.test;
 
 import com.google.gson.Gson;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/TestUtils.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/TestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test;
 
 import com.ibm.cloud.sdk.core.util.GsonSingleton;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/http/HttpConfigTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/http/HttpConfigTest.java
@@ -1,3 +1,16 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package com.ibm.cloud.sdk.core.test.http;
 
 import okhttp3.Authenticator;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/http/NameValueTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/http/NameValueTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.http;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/DynamicModelSerializationTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/DynamicModelSerializationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.model;
 
 import com.google.common.collect.Sets;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/GenericModelTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/GenericModelTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.model;
 
 import static org.testng.Assert.assertFalse;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/Foo.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/Foo.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2018 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.model.generated;
 
 import com.ibm.cloud.sdk.core.service.model.GenericModel;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPFoo.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPFoo.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2018 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.model.generated;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPFooBad.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPFooBad.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2018 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.model.generated;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPFooCtorExcp.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPFooCtorExcp.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2018 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.model.generated;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPFooNoCtor.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPFooNoCtor.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2018 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.model.generated;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPFooNullTypeToken.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPFooNullTypeToken.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2018 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.model.generated;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPInteger.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPInteger.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2018 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.model.generated;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPObject.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPObject.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2018 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.model.generated;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPProtectedCtor.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPProtectedCtor.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2018 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.model.generated;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPString.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/generated/ModelAPString.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2018 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.model.generated;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/BasicAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/BasicAuthenticatorTest.java
@@ -1,3 +1,16 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package com.ibm.cloud.sdk.core.test.security;
 
 import com.google.common.io.BaseEncoding;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/BearerTokenAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/BearerTokenAuthenticatorTest.java
@@ -1,3 +1,16 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package com.ibm.cloud.sdk.core.test.security;
 
 import static junit.framework.TestCase.assertNotNull;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/ConfigBasedAuthenticatorFactoryTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/ConfigBasedAuthenticatorFactoryTest.java
@@ -44,8 +44,8 @@ public class ConfigBasedAuthenticatorFactoryTest {
   // Creates a mock set of environment variables that are returned by EnvironmentUtils.getenv().
   private Map<String, String> getTestProcessEnvironment() {
     Map<String, String> env = new HashMap<>();
-    env.put("SERVICE1_URL", "https://service1/api");
-    env.put("SERVICE1_DISABLE_SSL", "true");
+    env.put("SERVICE_1_URL", "https://service1/api");
+    env.put("SERVICE_1_DISABLE_SSL", "true");
     env.put("SERVICE2_URL", "https://service2/api");
     env.put("SERVICE2_DISABLE_SSL", "false");
     env.put("SERVICE3_URL", "https://service3/api");
@@ -54,16 +54,16 @@ public class ConfigBasedAuthenticatorFactoryTest {
     env.put("SERVICE4_DISABLE_SSL", "false");
     env.put("SERVICE5_URL", "https://service5/api");
     env.put("SERVICE5_DISABLE_SSL", "true");
-    env.put("SERVICE1_AUTH_TYPE", Authenticator.AUTHTYPE_IAM);
-    env.put("SERVICE1_APIKEY", "my-api-key");
-    env.put("SERVICE1_CLIENT_ID", "my-client-id");
-    env.put("SERVICE1_CLIENT_SECRET", "my-client-secret");
-    env.put("SERVICE1_AUTH_URL", "https://iamhost/iam/api");
-    env.put("SERVICE1_IAM_DISABLE_SSL", "true");
+    env.put("SERVICE_1_AUTH_TYPE", "IaM");
+    env.put("SERVICE_1_APIKEY", "my-api-key");
+    env.put("SERVICE_1_CLIENT_ID", "my-client-id");
+    env.put("SERVICE_1_CLIENT_SECRET", "my-client-secret");
+    env.put("SERVICE_1_AUTH_URL", "https://iamhost/iam/api");
+    env.put("SERVICE_1_IAM_DISABLE_SSL", "true");
     env.put("SERVICE2_AUTH_TYPE", Authenticator.AUTHTYPE_BASIC);
     env.put("SERVICE2_USERNAME", "my-user");
     env.put("SERVICE2_PASSWORD", "my-password");
-    env.put("SERVICE3_AUTH_TYPE", Authenticator.AUTHTYPE_CP4D);
+    env.put("SERVICE3_AUTH_TYPE", "Cp4D");
     env.put("SERVICE3_AUTH_URL", "https://cp4dhost/cp4d/api");
     env.put("SERVICE3_USERNAME", "my-cp4d-user");
     env.put("SERVICE3_PASSWORD", "my-cp4d-password");
@@ -72,6 +72,7 @@ public class ConfigBasedAuthenticatorFactoryTest {
     env.put("SERVICE5_AUTH_TYPE", Authenticator.AUTHTYPE_BEARER_TOKEN);
     env.put("SERVICE5_BEARER_TOKEN", "my-bearer-token");
     env.put("ERROR1_AUTH_TYPE", Authenticator.AUTHTYPE_CP4D);
+    env.put("ERROR2_AUTH_TYPE", "BAD_AUTH_TYPE");
 
     return env;
   }
@@ -92,7 +93,7 @@ public class ConfigBasedAuthenticatorFactoryTest {
     PowerMockito.spy(EnvironmentUtils.class);
     PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(null);
 
-    Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service1");
+    Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service-1");
     assertNull(auth);
   }
 
@@ -102,7 +103,7 @@ public class ConfigBasedAuthenticatorFactoryTest {
     PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
     assertEquals(ALTERNATE_CRED_FILENAME, EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE"));
 
-    Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service1");
+    Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service-1");
     assertNotNull(auth);
     assertEquals(Authenticator.AUTHTYPE_IAM, auth.authenticationType());
   }
@@ -171,12 +172,20 @@ public class ConfigBasedAuthenticatorFactoryTest {
     ConfigBasedAuthenticatorFactory.getAuthenticator("error3");
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testFileCredentialsError4() {
+    PowerMockito.spy(EnvironmentUtils.class);
+    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+
+    ConfigBasedAuthenticatorFactory.getAuthenticator("error4");
+  }
+
   @Test
   public void testEnvCredentialsService1() {
     PowerMockito.spy(EnvironmentUtils.class);
     PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
-    Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service1");
+    Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service-1");
     assertNotNull(auth);
     assertEquals(Authenticator.AUTHTYPE_IAM, auth.authenticationType());
   }
@@ -187,6 +196,14 @@ public class ConfigBasedAuthenticatorFactoryTest {
     PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     ConfigBasedAuthenticatorFactory.getAuthenticator("error1");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testEnvCredentialsError2() {
+    PowerMockito.spy(EnvironmentUtils.class);
+    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+
+    ConfigBasedAuthenticatorFactory.getAuthenticator("error2");
   }
 
   @Test

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/ConfigBasedAuthenticatorFactoryTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/ConfigBasedAuthenticatorFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.security;
 
 import static com.ibm.cloud.sdk.core.test.TestUtils.getStringFromInputStream;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dAuthenticatorTest.java
@@ -1,3 +1,16 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package com.ibm.cloud.sdk.core.test.security;
 
 import static com.ibm.cloud.sdk.core.test.TestUtils.loadFixture;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/IamAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/IamAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.security;
 
 import static com.ibm.cloud.sdk.core.test.TestUtils.loadFixture;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/JsonWebTokenTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/JsonWebTokenTest.java
@@ -1,3 +1,15 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.ibm.cloud.sdk.core.test.security;
 
 import org.junit.Test;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/AuthenticationTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/AuthenticationTest.java
@@ -22,7 +22,7 @@ public class AuthenticationTest {
   private static final String BASIC_USERNAME = "basicUser";
 
   public class TestService extends BaseService {
-    private static final String SERVICE_NAME = "service1";
+    private static final String SERVICE_NAME = "service-1";
 
     public TestService() {
       this(null);

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/AuthenticationTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/AuthenticationTest.java
@@ -1,3 +1,16 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package com.ibm.cloud.sdk.core.test.service;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/BaseServiceTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/BaseServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.service;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/ErrorResponseTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/ErrorResponseTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.service;
 
 import com.ibm.cloud.sdk.core.http.HttpMediaType;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/HeadersTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/HeadersTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.service;
 
 import com.ibm.cloud.sdk.core.http.HttpMediaType;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestBuilderTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.service;
 
 import com.google.gson.JsonObject;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/ResponseTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/ResponseTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.test.service;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/util/CredentialUtilsTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/util/CredentialUtilsTest.java
@@ -53,8 +53,8 @@ public class CredentialUtilsTest {
 
   private Map<String, String> getTestProcessEnvironment() {
     Map<String, String> env = new HashMap<>();
-    env.put("SERVICE1_URL", "https://service1/api");
-    env.put("SERVICE1_DISABLE_SSL", "true");
+    env.put("SERVICE_1_URL", "https://service1/api");
+    env.put("SERVICE_1_DISABLE_SSL", "true");
     env.put("SERVICE2_URL", "https://service2/api");
     env.put("SERVICE2_DISABLE_SSL", "false");
     env.put("SERVICE3_URL", "https://service3/api");
@@ -63,16 +63,16 @@ public class CredentialUtilsTest {
     env.put("SERVICE4_DISABLE_SSL", "false");
     env.put("SERVICE5_URL", "https://service5/api");
     env.put("SERVICE5_DISABLE_SSL", "true");
-    env.put("SERVICE1_AUTH_TYPE", Authenticator.AUTHTYPE_IAM);
-    env.put("SERVICE1_APIKEY", "my-api-key");
-    env.put("SERVICE1_CLIENT_ID", "my-client-id");
-    env.put("SERVICE1_CLIENT_SECRET", "my-client-secret");
-    env.put("SERVICE1_AUTH_URL", "https://iamhost/iam/api");
-    env.put("SERVICE1_AUTH_DISABLE_SSL", "true");
+    env.put("SERVICE_1_AUTH_TYPE", Authenticator.AUTHTYPE_IAM);
+    env.put("SERVICE_1_APIKEY", "my-api-key");
+    env.put("SERVICE_1_CLIENT_ID", "my-client-id");
+    env.put("SERVICE_1_CLIENT_SECRET", "my-client-secret");
+    env.put("SERVICE_1_AUTH_URL", "https://iamhost/iam/api");
+    env.put("SERVICE_1_AUTH_DISABLE_SSL", "true");
     env.put("SERVICE2_AUTH_TYPE", Authenticator.AUTHTYPE_BASIC);
     env.put("SERVICE2_USERNAME", "my-user");
     env.put("SERVICE2_PASSWORD", "my-password");
-    env.put("SERVICE3_AUTH_TYPE", Authenticator.AUTHTYPE_CP4D);
+    env.put("SERVICE3_AUTH_TYPE", "Cp4D");
     env.put("SERVICE3_AUTH_URL", "https://cp4dhost/cp4d/api");
     env.put("SERVICE3_USERNAME", "my-cp4d-user");
     env.put("SERVICE3_PASSWORD", "my-cp4d-password");
@@ -146,7 +146,7 @@ public class CredentialUtilsTest {
   public void testFileCredentialsMapEmpty() {
     PowerMockito.spy(EnvironmentUtils.class);
     PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(null);
-    Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service1");
+    Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service-1");
     assertTrue(props.isEmpty());
   }
 
@@ -156,7 +156,7 @@ public class CredentialUtilsTest {
     PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
     assertEquals(ALTERNATE_CRED_FILENAME, EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE"));
 
-    Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service1");
+    Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service-1");
     verifyMapService1(props);
   }
 
@@ -204,7 +204,7 @@ public class CredentialUtilsTest {
   public void testEnvCredentialsMapEmpty() {
     PowerMockito.spy(EnvironmentUtils.class);
     PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(new HashMap<String, String>());
-    Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service1");
+    Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service-1");
     assertTrue(props.isEmpty());
   }
 
@@ -213,7 +213,7 @@ public class CredentialUtilsTest {
     PowerMockito.spy(EnvironmentUtils.class);
     PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
-    Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service1");
+    Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service-1");
     verifyMapService1(props);
   }
 
@@ -310,7 +310,7 @@ public class CredentialUtilsTest {
   private void verifyMapService3(Map<String, String> props) {
     assertNotNull(props);
     assertFalse(props.isEmpty());
-    assertEquals(Authenticator.AUTHTYPE_CP4D, props.get(Authenticator.PROPNAME_AUTH_TYPE));
+    assertEquals("Cp4D", props.get(Authenticator.PROPNAME_AUTH_TYPE));
     assertEquals("my-cp4d-user", props.get(CloudPakForDataAuthenticator.PROPNAME_USERNAME));
     assertEquals("my-cp4d-password", props.get(CloudPakForDataAuthenticator.PROPNAME_PASSWORD));
     assertEquals("https://cp4dhost/cp4d/api", props.get(CloudPakForDataAuthenticator.PROPNAME_URL));

--- a/src/test/java/com/ibm/cloud/sdk/core/util/ByteArrayTypeAdapterTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/ByteArrayTypeAdapterTest.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.ibm.cloud.sdk.core.test.util;
+package com.ibm.cloud.sdk.core.util;
 
 import static org.testng.Assert.assertEquals;
 

--- a/src/test/java/com/ibm/cloud/sdk/core/util/ByteArrayTypeAdapterTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/ByteArrayTypeAdapterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import static org.testng.Assert.assertEquals;

--- a/src/test/java/com/ibm/cloud/sdk/core/util/CredentialUtilsTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/CredentialUtilsTest.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.ibm.cloud.sdk.core.test.util;
+package com.ibm.cloud.sdk.core.util;
 
 import static com.ibm.cloud.sdk.core.test.TestUtils.getStringFromInputStream;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/ibm/cloud/sdk/core/util/CredentialUtilsTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/CredentialUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import static com.ibm.cloud.sdk.core.test.TestUtils.getStringFromInputStream;

--- a/src/test/java/com/ibm/cloud/sdk/core/util/DateDeserializerTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/DateDeserializerTest.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.ibm.cloud.sdk.core.test.util;
+package com.ibm.cloud.sdk.core.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/com/ibm/cloud/sdk/core/util/DateDeserializerTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/DateDeserializerTest.java
@@ -1,16 +1,16 @@
-/*
- * Copyright 2017 IBM Corp. All Rights Reserved.
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/ibm/cloud/sdk/core/util/GsonSingletonTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/GsonSingletonTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import java.lang.reflect.Type;

--- a/src/test/java/com/ibm/cloud/sdk/core/util/GsonSingletonTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/GsonSingletonTest.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.ibm.cloud.sdk.core.test.util;
+package com.ibm.cloud.sdk.core.util;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;

--- a/src/test/java/com/ibm/cloud/sdk/core/util/RequestUtilsTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/RequestUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import com.google.common.collect.Lists;

--- a/src/test/java/com/ibm/cloud/sdk/core/util/RequestUtilsTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/RequestUtilsTest.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.ibm.cloud.sdk.core.test.util;
+package com.ibm.cloud.sdk.core.util;
 
 import com.google.common.collect.Lists;
 import com.ibm.cloud.sdk.core.util.RequestUtils;

--- a/src/test/java/com/ibm/cloud/sdk/core/util/ValidatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/ValidatorTest.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.ibm.cloud.sdk.core.test.util;
+package com.ibm.cloud.sdk.core.util;
 
 import java.util.ArrayList;
 

--- a/src/test/java/com/ibm/cloud/sdk/core/util/ValidatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/ValidatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 IBM Corp. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2015, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.sdk.core.util;
 
 import java.util.ArrayList;

--- a/src/test/resources/my-credentials.env
+++ b/src/test/resources/my-credentials.env
@@ -1,6 +1,6 @@
 # Service-specific properties not related to authentication.
-SERVICE1_URL=https://service1/api
-SERVICE1_DISABLE_SSL=true
+SERVICE_1_URL=https://service1/api
+SERVICE_1_DISABLE_SSL=true
 
 SERVICE2_URL=https://service2/api
 SERVICE2_DISABLE_SSL=false
@@ -15,12 +15,12 @@ SERVICE5_URL=https://service5/api
 SERVICE5_DISABLE_SSL=true
 
 # Service1 configured with IAM
-SERVICE1_AUTH_TYPE=iam
-SERVICE1_APIKEY=my-api-key
-SERVICE1_CLIENT_ID=my-client-id
-SERVICE1_CLIENT_SECRET=my-client-secret
-SERVICE1_AUTH_URL=https://iamhost/iam/api
-SERVICE1_AUTH_DISABLE_SSL=true
+SERVICE_1_AUTH_TYPE=iam
+SERVICE_1_APIKEY=my-api-key
+SERVICE_1_CLIENT_ID=my-client-id
+SERVICE_1_CLIENT_SECRET=my-client-secret
+SERVICE_1_AUTH_URL=https://iamhost/iam/api
+SERVICE_1_AUTH_DISABLE_SSL=true
 
 # Service2 configured with Basic Auth
 SERVICE2_AUTH_TYPE=basic
@@ -28,7 +28,7 @@ SERVICE2_USERNAME=my-user
 SERVICE2_PASSWORD=my-password
 
 # Service3 configured with CP4D
-SERVICE3_AUTH_TYPE=cp4d
+SERVICE3_AUTH_TYPE=Cp4D
 SERVICE3_AUTH_URL=https://cp4dhost/cp4d/api
 SERVICE3_USERNAME=my-cp4d-user
 SERVICE3_PASSWORD=my-cp4d-password
@@ -42,12 +42,15 @@ SERVICE5_AUTH_TYPE=bearerToken
 SERVICE5_BEARER_TOKEN=my-bearer-token
 
 # Error1 - missing APIKEY
-ERROR1_AUTH_TYPE=iam
+ERROR1_AUTH_TYPE=IAM
 
 # Error2 - missing username
-ERROR2_AUTH_TYPE=basic
+ERROR2_AUTH_TYPE=BaSiC
 ERROR2_PASSWORD=password
 
 # Error3 - missing access token
 ERROR3_AUTH_TYPE=bearerToken
 ERROR3_BEARER_TOKEN=
+
+# Error4 - bad auth type
+ERROR4_AUTH_TYPE=BAD_AUTH_TYPE


### PR DESCRIPTION
This PR does the following:
1. When using the service name to retrieve external configuration properties (credential file or environment variables) any "-" (dash) characters are replaced with an "_" (underscore) character (in addition to folding the service name to upper case).
2. When using the <servicename>_AUTH_TYPE config property to determine which type authenticator should be created, we'll now use a case-insensitive comparison to be a little more lenient.