### PR TITLE
feat: defer validation of serviceURL until first use

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/http/RequestBuilder.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/RequestBuilder.java
@@ -108,12 +108,13 @@ public class RequestBuilder {
   /**
    * Creates a properly encoded HttpUrl object with no path parameters.
    *
-   * @param endPoint the API end point
+   * @param serviceUrl the base service URL associated with the service instance
    * @param pathSegments the path segments for a specific API call
    * @return the HttpUrl object
    */
-  public static HttpUrl constructHttpUrl(String endPoint, String[] pathSegments) {
-    HttpUrl.Builder httpUrlBuilder = HttpUrl.parse(endPoint).newBuilder();
+  public static HttpUrl constructHttpUrl(String serviceUrl, String[] pathSegments) {
+    Validator.notEmpty(serviceUrl, "The serviceUrl cannot be null");
+    HttpUrl.Builder httpUrlBuilder = HttpUrl.parse(serviceUrl).newBuilder();
     for (String segment : pathSegments) {
       httpUrlBuilder.addPathSegments(segment);
     }
@@ -123,13 +124,14 @@ public class RequestBuilder {
   /**
    * Creates a properly encoded HttpUrl object with path parameters.
    *
-   * @param endPoint the API end point
+   * @param serviceUrl the base service URL associated with the service instance
    * @param pathSegments the path segments for a specific API call
    * @param pathParameters the path parameters for a specific API call
    * @return the HttpUrl object
    */
-  public static HttpUrl constructHttpUrl(String endPoint, String[] pathSegments, String[] pathParameters) {
-    HttpUrl.Builder httpUrlBuilder = HttpUrl.parse(endPoint).newBuilder();
+  public static HttpUrl constructHttpUrl(String serviceUrl, String[] pathSegments, String[] pathParameters) {
+    Validator.notEmpty(serviceUrl, "The serviceUrl cannot be null");
+    HttpUrl.Builder httpUrlBuilder = HttpUrl.parse(serviceUrl).newBuilder();
     for (int i = 0; i < pathSegments.length; i++) {
       httpUrlBuilder.addPathSegments(pathSegments[i]);
       if (i < pathParameters.length) {

--- a/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
@@ -63,7 +63,7 @@ public abstract class BaseService {
 
   private static final String ERRORMSG_NO_AUTHENTICATOR = "Authentication information was not properly configured.";
 
-  private String endPoint;
+  private String serviceUrl;
   private final String name;
   private Authenticator authenticator;
 
@@ -101,7 +101,7 @@ public abstract class BaseService {
     Map<String, String> props = CredentialUtils.getServiceProperties(name);
     String url = props.get(PROPNAME_URL);
     if (StringUtils.isNotEmpty(url)) {
-      setEndPoint(url);
+      this.setServiceUrl(url);
     }
 
     // Configure a default client instance.
@@ -229,16 +229,6 @@ public abstract class BaseService {
   }
 
   /**
-   * Gets the API end point.
-   *
-   *
-   * @return the API end point
-   */
-  public String getEndPoint() {
-    return endPoint;
-  }
-
-  /**
    * Gets the name.
    *
    * @return the name
@@ -265,20 +255,26 @@ public abstract class BaseService {
   }
 
   /**
+   * Gets the API end point.
+   *
+   *
+   * @return the API end point
+   * @deprecated Use getServiceURL() instead.
+   */
+  @Deprecated
+  public String getEndPoint() {
+    return this.getServiceUrl();
+  }
+
+  /**
    * Sets the end point.
    *
    * @param endPoint the new end point. Will be ignored if empty or null
+   * @deprecated Use setServiceURL() instead.
    */
+  @Deprecated
   public void setEndPoint(final String endPoint) {
-    if (CredentialUtils.hasBadStartOrEndChar(endPoint)) {
-      throw new IllegalArgumentException("The URL shouldn't start or end with curly brackets or quotes. Please "
-          + "remove any surrounding {, }, or \" characters.");
-    }
-
-    if ((endPoint != null) && !endPoint.isEmpty()) {
-      String newEndPoint = endPoint.endsWith("/") ? endPoint.substring(0, endPoint.length() - 1) : endPoint;
-      this.endPoint = newEndPoint;
-    }
+    this.setServiceUrl(endPoint);
   }
 
   /**
@@ -302,6 +298,32 @@ public abstract class BaseService {
     return this.authenticator;
   }
 
+  /**
+   * Set the service URL (the base URL for the service instance).
+   * @param serviceUrl the new service URL value
+   */
+  public void setServiceUrl(String serviceUrl) {
+    if (CredentialUtils.hasBadStartOrEndChar(serviceUrl)) {
+      throw new IllegalArgumentException("The URL shouldn't start or end with curly brackets or quotes. Please "
+          + "remove any surrounding {, }, or \" characters.");
+    }
+
+    // Remove any potential trailing / character from the input value.
+    String newValue = serviceUrl;
+    if ((newValue != null) && !newValue.isEmpty()) {
+      newValue = newValue.endsWith("/") ? newValue.substring(0, newValue.length() - 1) : newValue;
+    }
+    this.serviceUrl = newValue;
+  }
+
+  /**
+   * Returns the service URL value associated with this service instance.
+   * @return the service URL
+   */
+  public String getServiceUrl() {
+    return this.serviceUrl;
+  }
+
   /*
    * (non-Javadoc)
    *
@@ -310,11 +332,7 @@ public abstract class BaseService {
   @Override
   public String toString() {
     final StringBuilder builder = new StringBuilder().append(name).append(" [");
-
-    if (endPoint != null) {
-      builder.append("endPoint=").append(endPoint);
-    }
-
+    builder.append("serviceUrl=").append(serviceUrl != null ? serviceUrl : "<null>");
     return builder.append(']').toString();
   }
 

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/AuthenticationTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/AuthenticationTest.java
@@ -89,7 +89,7 @@ public class AuthenticationTest {
     TestService service = new TestService("natural_language_classifier", null);
     assertNotNull(service.getAuthenticator());
     assertEquals(Authenticator.AUTHTYPE_IAM, service.getAuthenticator().authenticationType());
-    assertEquals("https://gateway.watsonplatform.net/natural-language-classifier/api", service.getEndPoint());
+    assertEquals("https://gateway.watsonplatform.net/natural-language-classifier/api", service.getServiceUrl());
     OkHttpClient client = service.getClient();
     assertNotNull(client);
     assertFalse(client.hostnameVerifier() instanceof OkHostnameVerifier);

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/ErrorResponseTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/ErrorResponseTest.java
@@ -52,7 +52,7 @@ public class ErrorResponseTest extends BaseServiceUnitTest {
     }
 
     ServiceCall<GenericModel> testMethod() {
-      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getEndPoint() + "/v1/test"));
+      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       return createServiceCall(builder.build(), ResponseConverterUtils.getObject(GenericModel.class));
     }
   }
@@ -69,7 +69,7 @@ public class ErrorResponseTest extends BaseServiceUnitTest {
   public void setUp() throws Exception {
     super.setUp();
     service = new TestService(new NoAuthAuthenticator());
-    service.setEndPoint(getMockWebServerUrl());
+    service.setServiceUrl(getMockWebServerUrl());
   }
 
   /**

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/HeadersTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/HeadersTest.java
@@ -44,7 +44,7 @@ public class HeadersTest extends BaseServiceUnitTest {
     }
 
     public ServiceCall<TestModel> testMethod() {
-      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getEndPoint() + "/v1/test"));
+      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       return createServiceCall(builder.build(), ResponseConverterUtils.getObject(TestModel.class));
     }
   }
@@ -61,7 +61,7 @@ public class HeadersTest extends BaseServiceUnitTest {
   public void setUp() throws Exception {
     super.setUp();
     service = new TestService(new NoAuthAuthenticator());
-    service.setEndPoint(getMockWebServerUrl());
+    service.setServiceUrl(getMockWebServerUrl());
   }
 
   /**

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestBuilderTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestBuilderTest.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * The Class RequestBuilderTest.
@@ -244,5 +245,28 @@ public class RequestBuilderTest {
   public void testSpecialCharacterQuery() {
     final Request request = RequestBuilder.get(HttpUrl.parse(url)).query("ä&ö", "ö=ü").build();
     assertEquals(url + "?%C3%A4%26%C3%B6=%C3%B6%3D%C3%BC", request.url().toString());
+  }
+
+  @Test
+  public void testConstructHttpUrlGood() {
+    String[] pathSegments = { "v1/seg1", "seg2", "seg3"};
+    String[] pathParameters = { "param1", "param2" };
+    HttpUrl url = RequestBuilder.constructHttpUrl("https://myserver.com/testservice/api", pathSegments, pathParameters);
+    assertNotNull(url);
+    assertNotEquals("https://myserver.com/testservice/api/v1/seg1/param1/seg2/param3/seg3", url);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConstructHttpUrlEmpty() {
+    String[] pathSegments = { "v1/seg1", "seg2", "seg3"};
+    String[] pathParameters = { "param1", "param2" };
+    HttpUrl url = RequestBuilder.constructHttpUrl("", pathSegments, pathParameters);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConstructHttpUrlNull() {
+    String[] pathSegments = { "v1/seg1", "seg2", "seg3"};
+    String[] pathParameters = { "param1", "param2" };
+    HttpUrl url = RequestBuilder.constructHttpUrl(null, pathSegments, pathParameters);
   }
 }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/ResponseTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/ResponseTest.java
@@ -64,52 +64,52 @@ public class ResponseTest extends BaseServiceUnitTest {
     }
 
     ServiceCall<TestModel> getTestModel() {
-      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getEndPoint() + "/v1/test"));
+      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       return createServiceCall(builder.build(), ResponseConverterUtils.getObject(TestModel.class));
     }
 
     ServiceCall<TestModel> getTestModel2() {
-      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getEndPoint() + "/v1/test"));
+      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<TestModel> responseConverter =
           ResponseConverterUtils.getValue(new TypeToken<TestModel>(){}.getType());
       return createServiceCall(builder.build(), responseConverter);
     }
 
     ServiceCall<Void> headMethod() {
-      RequestBuilder builder = RequestBuilder.head(HttpUrl.parse(getEndPoint() + "/v1/test"));
+      RequestBuilder builder = RequestBuilder.head(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
     }
 
     ServiceCall<String> getString() {
-      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getEndPoint() + "/v1/test"));
+      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<String> responseConverter =
           ResponseConverterUtils.getValue(new TypeToken<String>(){}.getType());
       return createServiceCall(builder.build(), responseConverter);
     }
 
     ServiceCall<List<String>> getListString() {
-      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getEndPoint() + "/v1/test"));
+      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<List<String>> responseConverter =
           ResponseConverterUtils.getValue(new TypeToken<List<String>>(){}.getType());
       return createServiceCall(builder.build(), responseConverter);
     }
 
     ServiceCall<Long> getLong() {
-      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getEndPoint() + "/v1/test"));
+      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<Long> responseConverter =
           ResponseConverterUtils.getValue(new TypeToken<Long>(){}.getType());
       return createServiceCall(builder.build(), responseConverter);
     }
 
     ServiceCall<List<Long>> getListLong() {
-      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getEndPoint() + "/v1/test"));
+      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<List<Long>> responseConverter =
           ResponseConverterUtils.getValue(new TypeToken<List<Long>>(){}.getType());
       return createServiceCall(builder.build(), responseConverter);
     }
 
     ServiceCall<List<TestModel>> getListTestModel() {
-      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getEndPoint() + "/v1/test"));
+      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<List<TestModel>> responseConverter =
           ResponseConverterUtils.getValue(new TypeToken<List<TestModel>>(){}.getType());
       return createServiceCall(builder.build(), responseConverter);
@@ -138,7 +138,7 @@ public class ResponseTest extends BaseServiceUnitTest {
   public void setUp() throws Exception {
     super.setUp();
     service = new TestService(new NoAuthAuthenticator());
-    service.setEndPoint(getMockWebServerUrl());
+    service.setServiceUrl(getMockWebServerUrl());
   }
 
   /**


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/1011

This PR contains the necessary changes in the Java core to support the new "paramterized URL" feature in the Java generator.
Summary:
1) The BaseService.endPoint field renamed to serviceURL.
2) Added getServiceURL/setServiceURL methods.
3) Deprecated getEndPoint/setEndPoint
4) Added validation of the base URL value to RequestBuilder.constructHttpUrl()
5) Updated tests as needed.