### PR TITLE
fix: fix javadoc warnings

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/service/model/FileWithMetadata.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/model/FileWithMetadata.java
@@ -113,6 +113,7 @@ public class FileWithMetadata {
          * Set the data.
          *
          * @param file the file to use as the source of file contents and filename
+         * @return the FileWithMetadata builder
          * @throws FileNotFoundException if the file could not be found
          */
         public Builder data(File file) throws FileNotFoundException {
@@ -141,6 +142,7 @@ public class FileWithMetadata {
 
     /**
      * The data / contents of the file.
+     * @return the contents of the file
      */
     public InputStream data() {
         return this.data;
@@ -148,6 +150,7 @@ public class FileWithMetadata {
 
     /**
      * The filename for file.
+     * @return the filename
      */
     public String filename() {
         return this.filename;
@@ -155,6 +158,7 @@ public class FileWithMetadata {
 
     /**
      * The content type of file. Values for this parameter can be obtained from the HttpMediaType class.
+     * @return the content-type associated with the file
      */
     public String contentType() {
         return this.contentType;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/BaseServiceTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/BaseServiceTest.java
@@ -13,15 +13,11 @@
 
 package com.ibm.cloud.sdk.core.test.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.testng.Assert.assertNotEquals;
+import static org.junit.Assert.*;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import com.ibm.cloud.sdk.core.http.HttpClientSingleton;
 import com.ibm.cloud.sdk.core.http.HttpConfigOptions;
@@ -38,14 +34,14 @@ import okhttp3.internal.tls.OkHostnameVerifier;
 public class BaseServiceTest {
 
   // Simulated generated service class.
-  public static class TestService extends BaseService {
+  public class TestService extends BaseService {
     public TestService(String name) {
       super(name, new NoAuthAuthenticator());
     }
   }
 
   // A second simulated generated service class.
-  public static class AnotherTestService extends BaseService {
+  public class AnotherTestService extends BaseService {
     public AnotherTestService(String name) {
       super(name, new NoAuthAuthenticator());
     }


### PR DESCRIPTION
Fixed a few javadoc warnings and fixed a bizarre timing-related issue in a unit test by changing it to use TestNG.