### PR TITLE
feat(BaseService): add new method ConfigureService() to BaseService class

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
@@ -101,15 +101,23 @@ public abstract class BaseService {
     }
     this.authenticator = authenticator;
 
+    // Configure a default client instance.
+    this.client = configureHttpClient();
+
+    // temp: set any external configuration from the constructor
+    configureService(name);
+  }
+
+  protected void configureService(String serviceName) {
+    if (serviceName == null || serviceName.isEmpty()) {
+      throw new IllegalArgumentException("Error configuring service. Service name is required.");
+    }
     // Try to retrieve the service URL from either a credential file, environment, or VCAP_SERVICES.
-    Map<String, String> props = CredentialUtils.getServiceProperties(name);
+    Map<String, String> props = CredentialUtils.getServiceProperties(serviceName);
     String url = props.get(PROPNAME_URL);
     if (StringUtils.isNotEmpty(url)) {
       this.setServiceUrl(url);
     }
-
-    // Configure a default client instance.
-    this.client = configureHttpClient();
 
     // Check to see if "disable ssl" was set in the service properties.
     Boolean disableSSL = Boolean.valueOf(props.get(PROPNAME_DISABLE_SSL));

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/ConfigureServiceTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/ConfigureServiceTest.java
@@ -1,0 +1,105 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.sdk.core.test.service;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.ibm.cloud.sdk.core.security.Authenticator;
+import com.ibm.cloud.sdk.core.security.BasicAuthenticator;
+import com.ibm.cloud.sdk.core.security.ConfigBasedAuthenticatorFactory;
+import com.ibm.cloud.sdk.core.service.BaseService;
+import com.ibm.cloud.sdk.core.util.EnvironmentUtils;
+import static com.ibm.cloud.sdk.core.test.TestUtils.getStringFromInputStream;
+
+import java.io.InputStream;
+
+/**
+ * Unit tests associated with the BaseService core class.
+ *
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ EnvironmentUtils.class })
+@PowerMockIgnore("javax.net.ssl.*")
+public class ConfigureServiceTest {
+  private static final String ALTERNATE_CRED_FILENAME = "src/test/resources/my-credentials.env";
+  private static final String VCAP_SERVICES = "vcap_services.json";
+  private static final String BASIC_USERNAME = "basicUser";
+  // Simulated generated service class.
+  public class TestService extends BaseService {
+    public TestService(String name, Authenticator authenticator) {
+      super(name,
+        (authenticator != null ? authenticator : ConfigBasedAuthenticatorFactory.getAuthenticator(name)));
+    }
+    public void configureSvc(String serviceName) {
+        configureService(serviceName);
+    }
+    
+  }
+  /**
+   * Setup.
+   */
+  public void setupVCAP() {
+    final InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(VCAP_SERVICES);
+    final String vcapServices = getStringFromInputStream(in);
+
+    PowerMockito.spy(EnvironmentUtils.class);
+    PowerMockito.when(EnvironmentUtils.getenv("VCAP_SERVICES")).thenReturn(vcapServices);
+  }
+
+  @Test
+  public void testConfigureServiceOnInitiation() {
+    PowerMockito.spy(EnvironmentUtils.class);
+    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+
+    TestService svc = new TestService("SERVICE_1", null);
+    assertEquals("https://service1/api", svc.getServiceUrl());
+  }
+
+  @Test
+  public void testConfigureServiceViaCredFile() {
+    BasicAuthenticator auth = new BasicAuthenticator(BASIC_USERNAME, "password1");
+    TestService svc = new TestService("SERVICE_1", auth);
+    assertEquals(null, svc.getServiceUrl());
+
+    PowerMockito.spy(EnvironmentUtils.class);
+    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    svc.configureSvc("SERVICE_1");
+    assertEquals("https://service1/api", svc.getServiceUrl());
+  }
+
+  @Test
+  public void testConfigureServiceViaVcap() {
+    BasicAuthenticator auth = new BasicAuthenticator(BASIC_USERNAME, "password1");
+    TestService svc = new TestService("discovery", auth);
+    assertEquals(null, svc.getServiceUrl());
+
+    setupVCAP();
+    svc.configureSvc("discovery");
+    assertEquals("https://gateway.watsonplatform.net/discovery-experimental/api", svc.getServiceUrl());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConfigureServiceFailure() {
+    BasicAuthenticator auth = new BasicAuthenticator(BASIC_USERNAME, "password1");
+    TestService svc = new TestService("discovery", auth);
+    svc.configureSvc("");
+  }
+}


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/1120

Changes:
- moved the external configuration code outside of the constructor into it's own method.
- for compatibility, the constructor calls the new method until we move to the service factory's complete implementation.
- created a new test case for the configureservice method since PowerMock is dependent on JUnit, and the BaseServiceTest class was written using TestNG. PowerMock was needed to mock environment variables

