### PR TITLE
feat: enhancing vcap parsing & removing configureService reference from BaseService ctor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ config
 .iml
 .pre-commit-config.yaml
 .secrets.baseline
+.vscode/

--- a/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
@@ -103,12 +103,9 @@ public abstract class BaseService {
 
     // Configure a default client instance.
     this.client = configureHttpClient();
-
-    // temp: set any external configuration from the constructor
-    configureService(name);
   }
 
-  protected void configureService(String serviceName) {
+  public void configureService(String serviceName) {
     if (serviceName == null || serviceName.isEmpty()) {
       throw new IllegalArgumentException("Error configuring service. Service name is required.");
     }

--- a/src/main/java/com/ibm/cloud/sdk/core/util/CredentialUtils.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/CredentialUtils.java
@@ -183,9 +183,8 @@ public final class CredentialUtils {
       }
       // Second, try to find a service list with the specified key.
       List<VcapService> services = vcapObj.get(serviceName);
-      if (services != null && services.size() > 0) {
-        VcapService service = (services.get(0) != null) ? services.get(0) : null;
-        return service;
+      if (services != null && !services.isEmpty()) {
+        return services.get(0);
       }
     }
     return null;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/AuthenticationTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/AuthenticationTest.java
@@ -49,6 +49,10 @@ public class AuthenticationTest {
       super(name,
         (authenticator != null ? authenticator : ConfigBasedAuthenticatorFactory.getAuthenticator(name)));
     }
+
+    public void configureSvc(String serviceName) {
+      configureService(serviceName);
+    }
   }
 
   @Test
@@ -87,6 +91,7 @@ public class AuthenticationTest {
   @Test
   public void testCredentialFileAuthenticator() {
     TestService service = new TestService("natural_language_classifier", null);
+    service.configureSvc("natural_language_classifier");
     assertNotNull(service.getAuthenticator());
     assertEquals(Authenticator.AUTHTYPE_IAM, service.getAuthenticator().authenticationType());
     assertEquals("https://gateway.watsonplatform.net/natural-language-classifier/api", service.getServiceUrl());

--- a/src/test/resources/vcap_services.json
+++ b/src/test/resources/vcap_services.json
@@ -45,6 +45,16 @@
             "username": "not-a-username",
             "password": "not-a-password"
          }
+      },
+      {
+         "name": "discovery2",
+         "label": "discovery2",
+         "plan": "experimental",
+         "credentials": {
+            "url": "https://gateway.watsonplatform.net/discovery-experimental/api",
+            "username": "not-a-username",
+            "password": "not-a-password"
+         }
       }
    ],
    "document_conversion": [
@@ -213,5 +223,92 @@
             "password": "not-a-password"
          }
       }
-   ]
+   ],
+   "no_matching_name": [
+      {
+         "name": "different_name_two",
+         "label": "different_name_two",
+         "plan": "different_name__two_plan",
+         "credentials": {
+            "url": "https://gateway.watsonplatform.net/different-name-two/api",
+            "username": "not-a-username",
+            "password": "not-a-password"
+         }
+      },
+      {
+         "name": "different_name",
+         "label": "different_name",
+         "plan": "different_name_plan",
+         "credentials": {
+            "url": "https://gateway.watsonplatform.net/different-name/api",
+            "username": "not-a-username",
+            "password": "not-a-password"
+         }
+      }
+   ],
+   "key_to_service_entry_1": [
+      {
+           "name": "service_entry_key_and_key_to_service_entries",
+           "label": "devops-insights",
+           "plan": "standard",
+           "credentials": {
+              "url": "https://on.the.toolchainplatform.net/devops-insights/api",
+               "username": "not-a-username",
+               "password": "not-a-password"
+           }
+      },
+      {
+         "name": "service_entry_key_and_key_to_service_entries_two",
+         "label": "devops-insights",
+         "plan": "standard",
+         "credentials": {
+            "url": "https://on.the.toolchainplatform.net/devops-insights-2/api",
+             "username": "not-a-username",
+             "password": "not-a-password"
+         }
+    }
+  ],
+  "key_to_service_entry_2": [
+     {
+          "label": "devops-insights",
+          "plan": "standard",
+          "credentials": {
+             "url": "https://on.the.toolchainplatform.net/devops-insights-3/api",
+              "username": "not-a-username-3",
+              "password": "not-a-password-3"
+          }
+     }
+ ],
+  "service_entry_key_and_key_to_service_entries": [
+     {
+        "name": "service_entry_key-2",
+        "label": "devops-insights",
+        "plan": "elite",
+        "credentials": {
+            "url": "https://on.the.toolchainplatform.net/devops-insights-2/api",
+            "username": "not-a-username-2",
+            "password": "not-a-password-2"
+        }
+   }
+  ],
+  "empty_service": [
+     
+  ],
+  "no-creds-service": [
+     {
+      "name": "no-creds-service-one",
+      "label": "devops-insights",
+      "plan": "elite",
+      "credentials": {
+         "url": "https://on.the.toolchainplatform.net/no-creds-service-one/api",
+         "username": "not-a-username-2",
+         "password": "not-a-password-2"
+      }
+     },
+     {
+      "name": "no-creds-service-two",
+      "label": "devops-insights",
+      "plan": "elite"
+     }
+  ]
 }


### PR DESCRIPTION
ref: https://github.ibm.com/arf/planning-sdk-squad/issues/1098

The vcap changes were based on @padamstx initial implementation in the service-factory branch. Thanks Phil!

Changes:
- removed the call to the ``configureService()`` method out of the constructor.
- updated the unit tests that were dependent on ``configureService()`` being called when instantiating the BaseService.
- updated how external configuration is loaded from a vcap file based on this [design](https://github.ibm.com/CloudEngineering/openapi-sdkgen/wiki/Design-Of-Service-Config-Changes]). Specifically, the parsing now checks for a matching service name within an entry, if it doesn't find any then it will return the first entry with a matching outer key to the service name.
- other general cleanup of unused code

