### PR TITLE
Close extra stream used to save byte array in InputStreamRequestBody

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/http/InputStreamRequestBody.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/InputStreamRequestBody.java
@@ -25,12 +25,14 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.logging.Logger;
 
 /**
  * RequestBody that takes an {@link InputStream}.
  *
  */
 public class InputStreamRequestBody extends RequestBody {
+  private static final Logger LOGGER = Logger.getLogger(InputStreamRequestBody.class.getName());
 
   private InputStream inputStream;
   private MediaType mediaType;
@@ -60,6 +62,12 @@ public class InputStreamRequestBody extends RequestBody {
     }
 
     this.bytes = outputStream.toByteArray();
+    try {
+      outputStream.close();
+    } catch (IOException e) {
+      LOGGER.severe("Could not close inputStream byte array.");
+      e.printStackTrace();
+    }
   }
 
   /*

--- a/src/main/java/com/ibm/cloud/sdk/core/http/InputStreamRequestBody.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/InputStreamRequestBody.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -65,7 +66,7 @@ public class InputStreamRequestBody extends RequestBody {
     try {
       outputStream.close();
     } catch (IOException e) {
-      LOGGER.severe("Could not close inputStream byte array.");
+      LOGGER.log(Level.SEVERE, "Could not close inputStream byte array.", e);
       e.printStackTrace();
     }
   }


### PR DESCRIPTION
I'm trying to take a look at [this issue](https://github.com/watson-developer-cloud/java-sdk/issues/1094) I got in the public Watson SDK. Basically, a user is seeing `OutOfMemory` errors when trying to send a large number of audio files. I haven't been able to replicate the issue.

They're claiming that this wasn't the case with v7.3.0 of the Java SDK. From a generated service perspective, I didn't see anything that might've been the culprit. I turned to the change in core version being used, which was v4.5.0 -> v7.0.0, to try and find the issue. You can see a diff of those versions here: https://github.com/IBM/java-sdk-core/compare/4.5.0...7.0.0

Looking through that I still didn't really see any issues. This change that I made was one thing that stood out to me as a possible memory leak. I tested the change and was still able to send file requests fine, so it doesn't break anything, but I still couldn't replicate the issue.

@padamstx would you have any idea what the issue might be? I think this might be worth doing anyway but I'm not sure it fixes the problem. I'm at a loss at the moment of where else to look, though.