### PR TITLE
fix: propagate token server exception to main request invocation thread

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/security/AbstractToken.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/AbstractToken.java
@@ -20,4 +20,22 @@ public abstract class AbstractToken {
   public abstract boolean isTokenValid();
   public abstract boolean needsRefresh();
   public abstract String getAccessToken();
+
+  // This field will be used to indicate that the most recent interaction with the token server
+  // resulted in an error.
+  private Throwable exception;
+
+  public AbstractToken() {
+  }
+
+  public AbstractToken(Throwable t) {
+    this.exception = t;
+  }
+
+  public Throwable getException() {
+    return exception;
+  }
+  public void setException(Throwable exception) {
+    this.exception = exception;
+  }
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/security/CloudPakForDataAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/CloudPakForDataAuthenticator.java
@@ -157,9 +157,15 @@ public class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(requestUrl, new String[0]));
 
     // Invoke the GET request.
-    Cp4dTokenResponse response = invokeRequest(builder, Cp4dTokenResponse.class);
+    Cp4dToken token;
+    try {
+      Cp4dTokenResponse response = invokeRequest(builder, Cp4dTokenResponse.class);
+      token = new Cp4dToken(response);
+    } catch (Throwable t) {
+      token = new Cp4dToken(t);
+    }
 
     // Construct a new Cp4dToken object from the response and return it.
-    return new Cp4dToken(response);
+    return token;
   }
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/security/IamAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/IamAuthenticator.java
@@ -212,7 +212,12 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
         .build();
     builder.body(formBody);
 
-    IamToken token = invokeRequest(builder, IamToken.class);
+    IamToken token;
+    try {
+      token = invokeRequest(builder, IamToken.class);
+    } catch (Throwable t) {
+      token = new IamToken(t);
+    }
     return token;
   }
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/security/IamToken.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/IamToken.java
@@ -32,6 +32,14 @@ public class IamToken extends AbstractToken implements ObjectModel, TokenServerR
   private Long expiration;
   private Long refreshTime;
 
+  public IamToken() {
+    super();
+  }
+
+  public IamToken(Throwable t) {
+    super(t);
+  }
+
   @Override
   public String getAccessToken() {
     return accessToken;
@@ -69,6 +77,10 @@ public class IamToken extends AbstractToken implements ObjectModel, TokenServerR
    */
   @Override
   public synchronized boolean needsRefresh() {
+    if (this.getException() != null) {
+      return true;
+    }
+
     if (this.refreshTime == null && getExpiresIn() != null && this.expiration != null) {
       Double fractionOfTimeToLive = 0.8;
       Long timeToLive = getExpiresIn();
@@ -93,6 +105,7 @@ public class IamToken extends AbstractToken implements ObjectModel, TokenServerR
    */
   @Override
   public boolean isTokenValid() {
-    return this.expiration == null || Clock.getCurrentTimeInSeconds() < this.expiration;
+    return this.getException() == null
+        && (this.expiration == null || Clock.getCurrentTimeInSeconds() < this.expiration);
   }
 }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/BaseServiceUnitTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/BaseServiceUnitTest.java
@@ -69,4 +69,14 @@ public class BaseServiceUnitTest {
   protected static MockResponse jsonResponse(Object body) {
     return new MockResponse().addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON).setBody(GSON.toJson(body));
   }
+
+  /**
+   * Create a MockResponse with JSON content type and the object serialized to JSON as body.
+   *
+   * @param body the body
+   * @return the mock response
+   */
+  protected static MockResponse errorResponse(int statusCode) {
+    return new MockResponse().setResponseCode(statusCode);
+  }
 }


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/1261

This PR will propagate an exception that occurs on the thread where the token service invocation is made... back to the main request thread where the authenticator's authenticate() method is being invoked.