### PR TITLE
fix: use correct json serialization for lists

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/http/RequestBuilder.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/RequestBuilder.java
@@ -337,11 +337,11 @@ public class RequestBuilder {
   public RequestBuilder bodyContent(String contentType, Object jsonContent, Object jsonPatchContent,
     InputStream nonJsonContent) {
     if (contentType != null) {
-      Gson requestGson = GsonSingleton.getGson().newBuilder().create();
+      Gson requestGson = GsonSingleton.getGsonWithoutPrettyPrinting().newBuilder().create();
       if (BaseService.isJsonMimeType(contentType)) {
-        this.bodyContent(requestGson.toJsonTree(jsonContent).getAsJsonObject().toString(), contentType);
+        this.bodyContent(requestGson.toJson(jsonContent), contentType);
       } else if (BaseService.isJsonPatchMimeType(contentType)) {
-        this.bodyContent(requestGson.toJsonTree(jsonPatchContent).getAsJsonObject().toString(), contentType);
+        this.bodyContent(requestGson.toJson(jsonPatchContent), contentType);
       } else {
         this.bodyContent(nonJsonContent, contentType);
       }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestBuilderTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestBuilderTest.java
@@ -17,6 +17,11 @@ import com.google.gson.JsonObject;
 import com.ibm.cloud.sdk.core.http.HttpMediaType;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
 import com.ibm.cloud.sdk.core.test.TestUtils;
+import com.ibm.cloud.sdk.core.test.model.generated.Car;
+import com.ibm.cloud.sdk.core.test.model.generated.Truck;
+import com.ibm.cloud.sdk.core.test.model.generated.Vehicle;
+import com.ibm.cloud.sdk.core.util.GsonSingleton;
+
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.Request;
@@ -26,7 +31,10 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -194,6 +202,28 @@ public class RequestBuilderTest {
     assertEquals(body, buffer.readUtf8());
     assertEquals(HttpMediaType.TEXT, requestedBody.contentType());
 
+  }
+
+  /**
+   * Test with list of models.
+   *
+   * @throws IOException Signals that an I/O exception has occurred.
+   */
+  @Test
+  public void testBodyContentList() throws IOException {
+    // add list of actual models
+    final List<Vehicle> listOfModels = new ArrayList<>();
+    listOfModels.add(new Truck.Builder().vehicleType("Truck").make("Ford").engineType("raptor").build());
+    listOfModels.add(new Car.Builder().vehicleType("Car").make("Ford").bodyStyle("mach-e").build());
+
+    final Request request = RequestBuilder.post(HttpUrl.parse(urlWithQuery))
+        .bodyContent("application/json", listOfModels, null, (InputStream) null).build();
+    final RequestBody requestedBody = request.body();
+    final Buffer buffer = new Buffer();
+    requestedBody.writeTo(buffer);
+
+    assertEquals(GsonSingleton.getGsonWithoutPrettyPrinting().toJson(listOfModels), buffer.readUtf8());
+    assertEquals(HttpMediaType.JSON, requestedBody.contentType());
   }
 
   /**


### PR DESCRIPTION
Fixes the case when a list formatted object is passed to the request builder. Now, this is converted to a string then passed to the content builder.