### PR TITLE
fix: add support for deserializing RFC3339 full-date values

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/util/DateDeserializer.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/DateDeserializer.java
@@ -42,6 +42,7 @@ public class DateDeserializer implements JsonDeserializer<Date> {
   private static final String DATE_WITH_SECONDS = "yyyy-MM-dd'T'HH:mm:ss";
   private static final String DATE_822 = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
   private static final String DATE_822_WITHOUT_MS = "yyyy-MM-dd'T'HH:mm:ssZ";
+  private static final String RFC3339_FULL_DATE = "yyyy-MM-dd";
 
   // SimpleDateFormat is NOT thread safe - they require private visibility and synchronized access
   private final SimpleDateFormat alchemyDateFormatter = new SimpleDateFormat(DATE_FROM_ALCHEMY);
@@ -51,10 +52,11 @@ public class DateDeserializer implements JsonDeserializer<Date> {
   private final SimpleDateFormat utcWithSecondsDateFormatter = new SimpleDateFormat(DATE_WITH_SECONDS);
   private final SimpleDateFormat rfc822DateFormatter = new SimpleDateFormat(DATE_822);
   private final SimpleDateFormat rfc822WithoutMsDateFormatter = new SimpleDateFormat(DATE_822_WITHOUT_MS);
+  private final SimpleDateFormat rfc3339FullDateFormatter = new SimpleDateFormat(RFC3339_FULL_DATE);
 
   private final List<SimpleDateFormat> dateFormatters =
       Arrays.asList(utcDateFormatter, utcWithoutSecondsDateFormatter, dialogDateFormatter,
-              alchemyDateFormatter, utcWithSecondsDateFormatter);
+              alchemyDateFormatter, utcWithSecondsDateFormatter, rfc3339FullDateFormatter);
 
   private final List<SimpleDateFormat> rfc822Formatters =
       Arrays.asList(rfc822DateFormatter, rfc822WithoutMsDateFormatter);

--- a/src/test/java/com/ibm/cloud/sdk/core/util/DateDeserializerTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/DateDeserializerTest.java
@@ -122,5 +122,16 @@ public class DateDeserializerTest {
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
+
+        // RFC3339 full-date
+        try {
+            String dateString = "2020-01-01";
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+            Date dateVal = dateFormat.parse(dateString);
+            JsonElement element = parser.parse("\"" + dateString + "\"");
+            assertEquals(deserializer.deserialize(element, null, null), dateVal);
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
     }
 }


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/1512

This PR adds an additional formatter to the DateDeserializer class to handle date values of the form "yyyy-MM-dd".