### PR TITLE
fix: trailing slash in request url & remove whitespace when parsing external config properties

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/http/RequestBuilder.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/RequestBuilder.java
@@ -116,7 +116,9 @@ public class RequestBuilder {
     Validator.notEmpty(serviceUrl, "The serviceUrl cannot be null");
     HttpUrl.Builder httpUrlBuilder = HttpUrl.parse(serviceUrl).newBuilder();
     for (String segment : pathSegments) {
-      httpUrlBuilder.addPathSegments(segment);
+      if (!segment.isEmpty()) {
+        httpUrlBuilder.addPathSegments(segment);
+      }
     }
     return httpUrlBuilder.build();
   }
@@ -133,8 +135,10 @@ public class RequestBuilder {
     Validator.notEmpty(serviceUrl, "The serviceUrl cannot be null");
     HttpUrl.Builder httpUrlBuilder = HttpUrl.parse(serviceUrl).newBuilder();
     for (int i = 0; i < pathSegments.length; i++) {
-      httpUrlBuilder.addPathSegments(pathSegments[i]);
-      if (i < pathParameters.length) {
+      if (!pathSegments[i].isEmpty()) {
+        httpUrlBuilder.addPathSegments(pathSegments[i]);
+      }
+      if (i < pathParameters.length && !pathParameters[i].isEmpty()) {
         httpUrlBuilder.addPathSegment(pathParameters[i]);
       }
     }

--- a/src/main/java/com/ibm/cloud/sdk/core/util/CredentialUtils.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/CredentialUtils.java
@@ -286,8 +286,8 @@ public final class CredentialUtils {
       Map<String, String> props = new HashMap<>();
       serviceName = serviceName.toUpperCase().replaceAll("-", "_") + "_";
       for (Map.Entry<String, String> entry : env.entrySet()) {
-        String key = entry.getKey();
-        String value = entry.getValue();
+        String key = entry.getKey().trim();
+        String value = entry.getValue().trim();
 
         if (key.startsWith(serviceName)) {
           String credentialName = key.substring(serviceName.length());
@@ -340,6 +340,7 @@ public final class CredentialUtils {
    */
   private static void addToMap(Map<String, String> map, String key, String value) {
     if (StringUtils.isNotEmpty(value)) {
+      value = value.trim();
       map.put(key, value);
     }
   }
@@ -371,8 +372,8 @@ public final class CredentialUtils {
         continue;
       }
 
-      String key = lineTokens[0];
-      String value = lineTokens[1];
+      String key = lineTokens[0].trim();
+      String value = lineTokens[1].trim();
 
       if (key.startsWith(serviceName)) {
         String credentialName = key.substring(serviceName.length());

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestBuilderTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestBuilderTest.java
@@ -286,6 +286,49 @@ public class RequestBuilderTest {
     assertNotEquals("https://myserver.com/testservice/api/v1/seg1/param1/seg2/param3/seg3", url);
   }
 
+  @Test
+  public void testConstructHttpUrlEmptyPath1() {
+    String[] pathSegments = { "", "discovery" };
+    HttpUrl url = RequestBuilder.constructHttpUrl("https://myserver.com/testservice/api", pathSegments);
+    assertNotNull(url);
+    assertEquals("https://myserver.com/testservice/api/discovery", url.toString());
+  }
+  
+  @Test
+  public void testConstructHttpUrlEmptyPath2() {
+    String[] pathSegments = { "" };
+    HttpUrl url = RequestBuilder.constructHttpUrl("https://myserver.com/testservice/api", pathSegments);
+    assertNotNull(url);
+    assertEquals("https://myserver.com/testservice/api", url.toString());
+  }
+
+  @Test
+  public void testConstructHttpUrlEmptyPathWParams() {
+    String[] pathSegments = { "" };
+    String[] pathParameters = { "param1", "param2" };
+    HttpUrl url = RequestBuilder.constructHttpUrl("https://myserver.com/testservice/api", pathSegments, pathParameters);
+    assertNotNull(url);
+    assertEquals("https://myserver.com/testservice/api/param1", url.toString());
+  }
+
+  @Test
+  public void testConstructHttpUrlWEmptyParams() {
+    String[] pathSegments = { "v1/seg1", "seg2", "seg3"};
+    String[] pathParameters = { "", "" };
+    HttpUrl url = RequestBuilder.constructHttpUrl("https://myserver.com/testservice/api", pathSegments, pathParameters);
+    assertNotNull(url);
+    assertEquals("https://myserver.com/testservice/api/v1/seg1/seg2/seg3", url.toString());
+  }
+
+  @Test
+  public void testConstructHttpUrlEmptyPathAndParams() {
+    String[] pathSegments = { "" };
+    String[] pathParameters = { "" };
+    HttpUrl url = RequestBuilder.constructHttpUrl("https://myserver.com/testservice/api", pathSegments, pathParameters);
+    assertNotNull(url);
+    assertEquals("https://myserver.com/testservice/api", url.toString());
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testConstructHttpUrlEmpty() {
     String[] pathSegments = { "v1/seg1", "seg2", "seg3"};

--- a/src/test/java/com/ibm/cloud/sdk/core/util/CredentialUtilsTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/CredentialUtilsTest.java
@@ -75,6 +75,8 @@ public class CredentialUtilsTest {
     env.put("SERVICE4_AUTH_TYPE", Authenticator.AUTHTYPE_NOAUTH);
     env.put("SERVICE5_AUTH_TYPE", Authenticator.AUTHTYPE_BEARER_TOKEN);
     env.put("SERVICE5_BEARER_TOKEN", "my-bearer-token");
+    env.put("  SERVICE6_URL", "  https://service6/api  ");
+    env.put("  SERVICE6_BEARER_TOKEN", "  my-bearer-token  ");
 
     return env;
   }
@@ -190,6 +192,16 @@ public class CredentialUtilsTest {
   }
 
   @Test
+  public void testFileCredentialsMapService6() {
+    PowerMockito.spy(EnvironmentUtils.class);
+    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    assertEquals(ALTERNATE_CRED_FILENAME, EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE"));
+
+    Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service6");
+    verifyMapService6(props);
+  }
+
+  @Test
   public void testEnvCredentialsMapEmpty() {
     PowerMockito.spy(EnvironmentUtils.class);
     PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(new HashMap<String, String>());
@@ -240,6 +252,15 @@ public class CredentialUtilsTest {
 
     Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service5");
     verifyMapService5(props);
+  }
+
+  @Test
+  public void testEnvCredentialsMapService6() {
+    PowerMockito.spy(EnvironmentUtils.class);
+    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+
+    Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service6");
+    verifyMapService6(props);
   }
 
   @Test
@@ -374,6 +395,16 @@ public class CredentialUtilsTest {
     assertEquals("https://gateway.watsonplatform.net/language-translator/api", props.get("URL"));
   }
 
+  @Test
+  public void testVcapCredentialsWhitespace() {
+    setupVCAP();
+
+    Map<String, String> props = CredentialUtils.getVcapCredentialsAsMap("whitespace");
+    assertNotNull(props);
+    assertFalse(props.isEmpty());
+    assertEquals("https://johnsnow/url/api/", props.get("URL"));
+  }
+
   private void verifyMapService1(Map<String, String> props) {
     assertNotNull(props);
     assertFalse(props.isEmpty());
@@ -413,6 +444,13 @@ public class CredentialUtilsTest {
     assertNotNull(props);
     assertFalse(props.isEmpty());
     assertEquals(Authenticator.AUTHTYPE_BEARER_TOKEN, props.get(Authenticator.PROPNAME_AUTH_TYPE));
+    assertEquals("my-bearer-token", props.get(Authenticator.PROPNAME_BEARER_TOKEN));
+  }
+
+  private void verifyMapService6(Map<String, String> props) {
+    assertNotNull(props);
+    assertFalse(props.isEmpty());
+    assertEquals("https://service6/api", props.get("URL"));
     assertEquals("my-bearer-token", props.get(Authenticator.PROPNAME_BEARER_TOKEN));
   }
 }

--- a/src/test/resources/my-credentials.env
+++ b/src/test/resources/my-credentials.env
@@ -41,6 +41,10 @@ SERVICE4_AUTH_TYPE=noAuth
 SERVICE5_AUTH_TYPE=bearerToken
 SERVICE5_BEARER_TOKEN=my-bearer-token
 
+# Service6 configured with whitespace
+SERVICE6_URL = https://service6/api
+SERVICE6_BEARER_TOKEN = my-bearer-token
+
 # Error1 - missing APIKEY
 ERROR1_AUTH_TYPE=IAM
 

--- a/src/test/resources/vcap_services.json
+++ b/src/test/resources/vcap_services.json
@@ -310,5 +310,17 @@
       "label": "devops-insights",
       "plan": "elite"
      }
-  ]
+  ],
+  "whitespace": [
+     {
+        "name": "whitespace",
+        "label": "devops-insights",
+        "plan": "elite",
+        "credentials": {
+           "url": " https://johnsnow/url/api/ ",
+           "username": "not-a-username-2",
+           "password": "not-a-password-2"
+         }
+      }
+   ]
 }


### PR DESCRIPTION
ref: https://github.ibm.com/arf/planning-sdk-squad/issues/1738, https://github.ibm.com/arf/planning-sdk-squad/issues/1742

Changes/fixes:
- Empty path segments `""` are no longer added to the request url to prevent the java request url builder library from adding a `/` in place of the empty path segment
- When parsing a credentials file (vcap or environment file), the credential's key/value pairs are trimmed of whitespace