### PR TITLE
fix: allow '=' character in environment config values

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/util/CredentialUtils.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/CredentialUtils.java
@@ -367,8 +367,8 @@ public final class CredentialUtils {
         continue;
       }
 
-      String[] lineTokens = line.split("=");
-      if (lineTokens.length != 2) {
+      String[] lineTokens = line.split("=", 2);
+      if (lineTokens.length != 2 || lineTokens.length == 0) {
         continue;
       }
 

--- a/src/test/resources/my-credentials.env
+++ b/src/test/resources/my-credentials.env
@@ -45,6 +45,14 @@ SERVICE5_BEARER_TOKEN=my-bearer-token
 SERVICE6_URL = https://service6/api
 SERVICE6_BEARER_TOKEN = my-bearer-token
 
+# Service7 configured with IAM and a token containing '='
+SERVICE_7_AUTH_TYPE=iam
+SERVICE_7_APIKEY=V4HXmoUtMjohnsnow=KotN
+SERVICE_7_CLIENT_ID=somefake========id
+SERVICE_7_CLIENT_SECRET===my-client-secret==
+SERVICE_7_AUTH_URL=https://iamhost/iam/api=
+SERVICE_7_AUTH_DISABLE_SSL=
+
 # Error1 - missing APIKEY
 ERROR1_AUTH_TYPE=IAM
 

--- a/src/test/resources/vcap_services.json
+++ b/src/test/resources/vcap_services.json
@@ -322,5 +322,21 @@
            "password": "not-a-password-2"
          }
       }
-   ]
+   ],
+   "equals-sign-test": [
+      {
+         "name": "equals-sign-test",
+         "label": "equals_sign",
+         "plan": "standard",
+         "credentials": {
+            "apikey": "V4HXmoUtMjohnsnow=KotN",
+            "iam_apikey_description": "Auto generated apikey...",
+            "iam_apikey_name": "auto-generated-apikey-111-222-333",
+            "iam_role_crn": "crn:v1:bluemix:public:iam::::serviceRole:Manager",
+            "iam_serviceid_crn": "crn:v1:staging:public:iam-identity::a/::serviceid:ServiceID-1234",
+            "url": "https://gateway.watsonplatform.net/testService",
+            "iam_url": "https://iamhost/iam/api="
+         }
+      }
+    ]
 }


### PR DESCRIPTION
ref: https://github.ibm.com/arf/planning-sdk-squad/issues/1759
Changes:
- allow for a env config property's value to contain the ``=`` character
- add unit test cases