### PR TITLE
Add setter for properties of DynamicModel

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/service/model/DynamicModel.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/model/DynamicModel.java
@@ -79,6 +79,16 @@ public abstract class DynamicModel<T> implements ObjectModel {
   }
 
   /**
+   * Sets the map containing the arbitrary properties set on this object.
+   *
+   * @param properties
+   *         a map containing arbitrary properties to set on this object
+   */
+  public void setProperties(Map<String, T> properties) {
+    this.dynamicProperties = new HashMap<String, T>(properties);
+  }
+
+  /**
    * Returns a map containing the arbitrary properties set on this object.
    *
    * @return a copy of the map containing arbitrary properties set on this object

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/DynamicModelSerializationTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/DynamicModelSerializationTest.java
@@ -29,6 +29,7 @@ import com.ibm.cloud.sdk.core.test.model.generated.ModelAPString;
 import com.ibm.cloud.sdk.core.util.GsonSingleton;
 import org.testng.annotations.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
@@ -313,6 +314,13 @@ public class DynamicModelSerializationTest {
 
     ModelAPFoo newModel = deserialize(serialize(model), ModelAPFoo.class);
     assertEquals(newModel, model);
+
+    Map<String, Foo> newProps = new HashMap<>();
+    newProps.put("soccer", newFoo);
+    model.setProperties(newProps);
+    assertEquals(model.getPropertyNames(), Sets.newHashSet("soccer"));
+    newProps.remove("soccer");
+    assertEquals(model.getPropertyNames(), Sets.newHashSet("soccer"));
 
     assertTrue(model.equals(model));
     assertFalse(model.equals(null));


### PR DESCRIPTION
This PR adds a setter for the dynamic properties of a DynamicModel -- a model with "additionalProperties". 

Tests are included.