### PR TITLE
fix: surface ServiceResponseError outside of RuntimeError

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/security/TokenRequestBasedAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/TokenRequestBasedAuthenticator.java
@@ -249,8 +249,13 @@ public abstract class TokenRequestBasedAuthenticator<T extends AbstractToken, R 
 
     // Check to see if an exception occurred during our last interaction with the token server.
     if (this.tokenData.getException() != null) {
-      throw new RuntimeException(ERRORMSG_REQ_FAILED, tokenData.getException());
-    }
+        Throwable t = tokenData.getException();
+        if (t instanceof RuntimeException) {
+          throw (RuntimeException) t;
+        } else {
+          throw new RuntimeException(ERRORMSG_REQ_FAILED, tokenData.getException());
+        }
+      }
 
     // Return the access token from our stored tokenData object.
     token = tokenData.getAccessToken();

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dAuthenticatorTest.java
@@ -285,10 +285,33 @@ public class Cp4dAuthenticatorTest extends BaseServiceUnitTest {
     try {
       authenticator.authenticate(requestBuilder);
       fail("Expected authenticate() to result in exception!");
+    } catch (ServiceResponseException excp) {
+      assertTrue(excp instanceof ServiceResponseException);
+    } catch (Throwable t) {
+      fail("Expected ServiceResponseException, not " + t.getClass().getSimpleName());
+    }
+  }
+
+  @Test
+  public void testApiErrorResponse() throws Throwable {
+    server.enqueue(jsonResponse("{'}"));
+
+    // Mock current time to ensure the token is valid.
+    PowerMockito.mockStatic(Clock.class);
+    PowerMockito.when(Clock.getCurrentTimeInSeconds()).thenReturn((long) 100);
+
+    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator(url, testUsername, testPassword);
+
+    Request.Builder requestBuilder = new Request.Builder().url("https://test.com");
+
+    // Calling authenticate should result in an exception.
+    try {
+      authenticator.authenticate(requestBuilder);
+      fail("Expected authenticate() to result in exception!");
     } catch (RuntimeException excp) {
       Throwable causedBy = excp.getCause();
       assertNotNull(causedBy);
-      assertTrue(causedBy instanceof ServiceResponseException);
+      assertTrue(causedBy instanceof IllegalStateException);
     } catch (Throwable t) {
       fail("Expected RuntimeException, not " + t.getClass().getSimpleName());
     }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/IamAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/IamAuthenticatorTest.java
@@ -338,6 +338,31 @@ public class IamAuthenticatorTest extends BaseServiceUnitTest {
     PowerMockito.when(Clock.getCurrentTimeInSeconds()).thenReturn((long) 100);
 
     IamAuthenticator authenticator = new IamAuthenticator(API_KEY);
+    authenticator.setURL(url);
+
+    Request.Builder requestBuilder = new Request.Builder().url("https://test.com");
+
+    // Calling authenticate should result in an exception.
+    try {
+      authenticator.authenticate(requestBuilder);
+      fail("Expected authenticate() to result in exception!");
+    } catch (ServiceResponseException excp) {
+      assertTrue(excp instanceof ServiceResponseException);
+    } catch (Throwable t) {
+      fail("Expected ServiceResponseException, not " + t.getClass().getSimpleName());
+    }
+  }
+
+  @Test
+  public void testApiResponseError() throws Throwable {
+    server.enqueue(jsonResponse("{'}"));
+
+    // Mock current time to ensure the token is valid.
+    PowerMockito.mockStatic(Clock.class);
+    PowerMockito.when(Clock.getCurrentTimeInSeconds()).thenReturn((long) 100);
+
+    IamAuthenticator authenticator = new IamAuthenticator(API_KEY);
+    authenticator.setURL(url);
 
     Request.Builder requestBuilder = new Request.Builder().url("https://test.com");
 
@@ -348,7 +373,7 @@ public class IamAuthenticatorTest extends BaseServiceUnitTest {
     } catch (RuntimeException excp) {
       Throwable causedBy = excp.getCause();
       assertNotNull(causedBy);
-      assertTrue(causedBy instanceof ServiceResponseException);
+      assertTrue(causedBy instanceof IllegalStateException);
     } catch (Throwable t) {
       fail("Expected RuntimeException, not " + t.getClass().getSimpleName());
     }


### PR DESCRIPTION
This PR will allow ServiceResponseErrors to be returned directly, as opposed to in the `causedBy:` of a RuntimeException.