### PR TITLE
fix: support serialization of models containing lists of discriminated subclasses

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/util/GsonSingleton.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/GsonSingleton.java
@@ -39,13 +39,16 @@ public final class GsonSingleton {
    * @param prettyPrint if true the JSON will be pretty printed
    * @return the {@link Gson}
    */
-  private static Gson createGson(Boolean prettyPrint) {
+  private static Gson createGson(boolean prettyPrint, boolean serializeNulls) {
     GsonBuilder builder = new GsonBuilder();
 
     registerTypeAdapters(builder);
 
     if (prettyPrint) {
       builder.setPrettyPrinting();
+    }
+    if (serializeNulls) {
+      builder.serializeNulls();
     }
     builder.disableHtmlEscaping();
     return builder.create();
@@ -76,7 +79,7 @@ public final class GsonSingleton {
    */
   public static synchronized Gson getGson() {
     if (gson == null) {
-      gson = createGson(true);
+      gson = createGson(true, false);
     }
     return gson;
   }
@@ -88,8 +91,16 @@ public final class GsonSingleton {
    */
   public static synchronized Gson getGsonWithoutPrettyPrinting() {
     if (gsonWithoutPrinting == null) {
-      gsonWithoutPrinting = createGson(false);
+      gsonWithoutPrinting = createGson(false, false);
     }
     return gsonWithoutPrinting;
+  }
+
+  /**
+   * Returns an instance of Gson with the "serialize nulls" config option enabled.
+   * @return
+   */
+  public static Gson getGsonWithSerializeNulls() {
+    return createGson(false, true);
   }
 }


### PR DESCRIPTION
Fixes arf/planning-sdk-squad#2011

We initially did not implement the "write()" method within the
DiscriminatorBasedTypeAdapterFactory because we should never
encounter an actual instance of a discriminated base class
(they are implemented as abstract base classes).

However, in some scenarios Gson will use a type adapter
that reflects the DECLARED type rather than the actual RUNTIME type
associated with an object.  One such scenario is when a class
contains a field which is defined as a List of some type X, where
X is a discriminated base class (oneOf parent).

For this reason, it's possible that the write() method is
called.  This commit implements the write() method so that it
simply delegates to the TypeAdapter associated with the
object's RUNTIME type.