### PR TITLE
feat: add method RequestBuilder.resolveRequestUrl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <compiler-plugin-version>3.8.0</compiler-plugin-version>
         <okhttp3-version>3.14.9</okhttp3-version>
         <logback-version>1.2.3</logback-version>
-        <guava-version>27.1-android</guava-version>
+        <guava-version>29.0-jre</guava-version>
         <gson-version>2.8.5</gson-version>
         <commons-codec-version>1.12</commons-codec-version>
         <commons-io-version>2.6</commons-io-version>


### PR DESCRIPTION
This commit adds method resolveRequestURL to the RequestBuilder class
as a replacement for the constructHttpUrl() method.