### PR TITLE
feat(IAM Authenticator): add support for optional 'scope' property

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/security/Authenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/Authenticator.java
@@ -41,6 +41,7 @@ public interface Authenticator {
   String PROPNAME_APIKEY = "APIKEY";
   String PROPNAME_CLIENT_ID = "CLIENT_ID";
   String PROPNAME_CLIENT_SECRET = "CLIENT_SECRET";
+  String PROPNAME_SCOPE = "SCOPE";
 
   /**
    * Validates the current set of configuration information in the Authenticator.

--- a/src/main/java/com/ibm/cloud/sdk/core/security/IamAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/IamAuthenticator.java
@@ -79,6 +79,30 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
   }
 
   /**
+   * Constructs an IamAuthenticator with all properties.
+   *
+   * @param apikey
+   *          the apikey to be used when retrieving the access token
+   * @param url
+   *          the URL representing the token server endpoint
+   * @param clientId
+   *          the clientId to be used in token server interactions
+   * @param clientSecret
+   *          the clientSecret to be used in token server interactions
+   * @param disableSSLVerification
+   *          a flag indicating whether SSL hostname verification should be disabled
+   * @param headers
+   *          a set of user-supplied headers to be included in token server interactions
+   * @param scope
+   *          the "scope" to use when fetching the bearer token from the IAM token server.
+   *          This can be used to obtain an access token with a specific scope.
+   */
+  public IamAuthenticator(String apikey, String url, String clientId, String clientSecret,
+    boolean disableSSLVerification, Map<String, String> headers, String scope) {
+    init(apikey, url, clientId, clientSecret, disableSSLVerification, headers, scope);
+  }
+
+  /**
    * Construct an IamAuthenticator instance using properties retrieved from the specified Map.
    * @param config a map containing the configuration properties
    */

--- a/src/main/java/com/ibm/cloud/sdk/core/security/IamAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/IamAuthenticator.java
@@ -33,6 +33,7 @@ import okhttp3.FormBody;
 public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, IamToken> implements Authenticator {
   private String apikey;
   private String url;
+  private String scope;
 
   private static final String DEFAULT_IAM_URL = "https://iam.cloud.ibm.com/identity/token";
   private static final String GRANT_TYPE = "grant_type";
@@ -40,6 +41,7 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
   private static final String API_KEY = "apikey";
   private static final String RESPONSE_TYPE = "response_type";
   private static final String CLOUD_IAM = "cloud_iam";
+  private static final String SCOPE = "scope";
 
   // The default ctor is hidden to force the use of the non-default ctors.
   protected IamAuthenticator() {
@@ -52,7 +54,7 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
    *          the apikey to be used when retrieving the access token
    */
   public IamAuthenticator(String apikey) {
-    init(apikey, null, null, null, false, null);
+    init(apikey, null, null, null, false, null, null);
   }
 
   /**
@@ -73,7 +75,7 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
    */
   public IamAuthenticator(String apikey, String url, String clientId, String clientSecret,
     boolean disableSSLVerification, Map<String, String> headers) {
-    init(apikey, url, clientId, clientSecret, disableSSLVerification, headers);
+    init(apikey, url, clientId, clientSecret, disableSSLVerification, headers, null);
   }
 
   /**
@@ -87,7 +89,7 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
     }
     init(apikey, config.get(PROPNAME_URL),
       config.get(PROPNAME_CLIENT_ID), config.get(PROPNAME_CLIENT_SECRET),
-      Boolean.valueOf(config.get(PROPNAME_DISABLE_SSL)).booleanValue(), null);
+      Boolean.valueOf(config.get(PROPNAME_DISABLE_SSL)).booleanValue(), null, config.get(PROPNAME_SCOPE));
   }
 
   /**
@@ -105,9 +107,12 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
    *          a flag indicating whether SSL hostname verification should be disabled
    * @param headers
    *          a set of user-supplied headers to be included in token server interactions
+   * @param scope
+   *          the "scope" to use when fetching the bearer token from the IAM token server.
+   *          This can be used to obtain an access token with a specific scope.
    */
   protected void init(String apikey, String url, String clientId, String clientSecret,
-    boolean disableSSLVerification, Map<String, String> headers) {
+    boolean disableSSLVerification, Map<String, String> headers, String scope) {
     this.apikey = apikey;
     if (StringUtils.isEmpty(url)) {
       url = DEFAULT_IAM_URL;
@@ -116,6 +121,7 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
     setDisableSSLVerification(disableSSLVerification);
     setHeaders(headers);
     setClientIdAndSecret(clientId, clientSecret);
+    setScope(scope);
   }
 
   @Override
@@ -195,6 +201,21 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
   }
 
   /**
+   * @return the scope parameter
+   */
+  public String getScope() {
+    return this.scope;
+  }
+
+  /**
+   * Sets the "scope" parameter to use when fetching the bearer token from the IAM token server.
+   * @param value a space seperated string that makes up the scope parameter.
+   */
+  public void setScope(String value) {
+    this.scope = value;
+  }
+
+  /**
    * Fetches an IAM access token for the apikey using the configured URL.
    *
    * @return an IamToken instance that contains the access token
@@ -205,11 +226,17 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
 
     // Now add the Content-Type and (optionally) the Authorization header to the token server request.
     builder.header(HttpHeaders.CONTENT_TYPE, HttpMediaType.APPLICATION_FORM_URLENCODED);
-    FormBody formBody = new FormBody.Builder()
+
+    FormBody formBody;
+    final FormBody.Builder formBodyBuilder = new FormBody.Builder()
         .add(GRANT_TYPE, REQUEST_GRANT_TYPE)
         .add(API_KEY, apikey)
-        .add(RESPONSE_TYPE, CLOUD_IAM)
-        .build();
+        .add(RESPONSE_TYPE, CLOUD_IAM);
+    // Add the scope param if it's not empty
+    if (!StringUtils.isEmpty(getScope())) {
+      formBodyBuilder.add(SCOPE, getScope());
+    }
+    formBody = formBodyBuilder.build();
     builder.body(formBody);
 
     IamToken token;

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/IamAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/IamAuthenticatorTest.java
@@ -177,6 +177,13 @@ public class IamAuthenticatorTest extends BaseServiceUnitTest {
   }
 
   @Test
+  public void testSetScopeThroughCtor() {
+    String scope = "scope1 scope2 scope3";
+    IamAuthenticator auth = new IamAuthenticator(API_KEY, url, null, null, false, null, scope);
+    assertEquals(scope, auth.getScope());
+  }
+
+  @Test
   public void testAuthenticateNewAndStoredToken() throws Throwable {
     server.enqueue(jsonResponse(tokenData));
 

--- a/src/test/java/com/ibm/cloud/sdk/core/util/CredentialUtilsTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/CredentialUtilsTest.java
@@ -82,6 +82,9 @@ public class CredentialUtilsTest {
     env.put("SERVICE_7_CLIENT_ID", "somefake========id");
     env.put("SERVICE_7_CLIENT_SECRET", "==my-client-secret==");
     env.put("SERVICE_7_AUTH_URL", "https://iamhost/iam/api=");
+    env.put("SERVICE_8_AUTH_TYPE", Authenticator.AUTHTYPE_IAM);
+    env.put("SERVICE_8_APIKEY", "V4HXmoUtMjohnsnow=KotN");
+    env.put("SERVICE_8_SCOPE", "A B C D");
 
     return env;
   }
@@ -121,6 +124,9 @@ public class CredentialUtilsTest {
     System.setProperty("SERVICE_7_CLIENT_ID", "somefake========id");
     System.setProperty("SERVICE_7_CLIENT_SECRET", "==my-client-secret==");
     System.setProperty("SERVICE_7_AUTH_URL", "https://iamhost/iam/api=");
+    System.setProperty("SERVICE_8_AUTH_TYPE", Authenticator.AUTHTYPE_IAM);
+    System.setProperty("SERVICE_8_APIKEY", "V4HXmoUtMjohnsnow=KotN");
+    System.setProperty("SERVICE_8_SCOPE", "A B C D");
   }
 
   private void clearTestSystemProps() {
@@ -158,6 +164,9 @@ public class CredentialUtilsTest {
     System.clearProperty("SERVICE_7_CLIENT_ID");
     System.clearProperty("SERVICE_7_CLIENT_SECRET");
     System.clearProperty("SERVICE_7_AUTH_URL");
+    System.clearProperty("SERVICE_8_AUTH_TYPE");
+    System.clearProperty("SERVICE_8_APIKEY");
+    System.clearProperty("SERVICE_8_SCOPE");
   }
 
   /**
@@ -291,6 +300,16 @@ public class CredentialUtilsTest {
   }
 
   @Test
+  public void testFileCredentialsMapService8() {
+    PowerMockito.spy(EnvironmentUtils.class);
+    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    assertEquals(ALTERNATE_CRED_FILENAME, EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE"));
+
+    Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service-8");
+    verifyMapService8(props);
+  }
+
+  @Test
   public void testFileCredentialsSystemPropEmpty() {
     System.setProperty("IBM_CREDENTIALS_FILE", "");
     Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service-1");
@@ -377,6 +396,17 @@ public class CredentialUtilsTest {
   }
 
   @Test
+  public void testFileCredentialsSystemPropService8() {
+    System.setProperty("IBM_CREDENTIALS_FILE", ALTERNATE_CRED_FILENAME);
+    assertEquals(ALTERNATE_CRED_FILENAME, System.getProperty("IBM_CREDENTIALS_FILE"));
+
+    Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service-8");
+    verifyMapService8(props);
+    System.clearProperty("IBM_CREDENTIALS_FILE");
+    assertNull(System.getProperty("IBM_CREDENTIALS_FILE"));
+  }
+
+  @Test
   public void testEnvCredentialsMapEmpty() {
     PowerMockito.spy(EnvironmentUtils.class);
     PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(new HashMap<String, String>());
@@ -445,6 +475,15 @@ public class CredentialUtilsTest {
 
     Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service-7");
     verifyMapService7(props);
+  }
+
+  @Test
+  public void testEnvCredentialsMapService8() {
+    PowerMockito.spy(EnvironmentUtils.class);
+    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+
+    Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service-8");
+    verifyMapService8(props);
   }
 
   @Test
@@ -519,6 +558,15 @@ public class CredentialUtilsTest {
 
     Map<String, String> props = CredentialUtils.getSystemPropsCredentialsAsMap("service-7");
     verifyMapService7(props);
+    clearTestSystemProps();
+  }
+
+  @Test
+  public void testSystemPropsCredentialsService8() {
+    setTestSystemProps();
+
+    Map<String, String> props = CredentialUtils.getSystemPropsCredentialsAsMap("service-8");
+    verifyMapService8(props);
     clearTestSystemProps();
   }
 
@@ -686,6 +734,7 @@ public class CredentialUtilsTest {
     assertEquals("my-client-id", props.get(Authenticator.PROPNAME_CLIENT_ID));
     assertEquals("https://iamhost/iam/api", props.get(Authenticator.PROPNAME_URL));
     assertEquals("true", props.get(Authenticator.PROPNAME_DISABLE_SSL));
+    assertNull(props.get(Authenticator.PROPNAME_SCOPE));
   }
 
   private void verifyMapService2(Map<String, String> props) {
@@ -694,6 +743,7 @@ public class CredentialUtilsTest {
     assertEquals(Authenticator.AUTHTYPE_BASIC, props.get(Authenticator.PROPNAME_AUTH_TYPE));
     assertEquals("my-user", props.get(Authenticator.PROPNAME_USERNAME));
     assertEquals("my-password", props.get(Authenticator.PROPNAME_PASSWORD));
+    assertNull(props.get(Authenticator.PROPNAME_SCOPE));
   }
 
   private void verifyMapService3(Map<String, String> props) {
@@ -704,12 +754,14 @@ public class CredentialUtilsTest {
     assertEquals("my-cp4d-password", props.get(CloudPakForDataAuthenticator.PROPNAME_PASSWORD));
     assertEquals("https://cp4dhost/cp4d/api", props.get(CloudPakForDataAuthenticator.PROPNAME_URL));
     assertEquals("false", props.get(CloudPakForDataAuthenticator.PROPNAME_DISABLE_SSL));
+    assertNull(props.get(Authenticator.PROPNAME_SCOPE));
   }
 
   private void verifyMapService4(Map<String, String> props) {
     assertNotNull(props);
     assertFalse(props.isEmpty());
     assertEquals(Authenticator.AUTHTYPE_NOAUTH, props.get(Authenticator.PROPNAME_AUTH_TYPE));
+    assertNull(props.get(Authenticator.PROPNAME_SCOPE));
   }
 
   private void verifyMapService5(Map<String, String> props) {
@@ -717,6 +769,7 @@ public class CredentialUtilsTest {
     assertFalse(props.isEmpty());
     assertEquals(Authenticator.AUTHTYPE_BEARER_TOKEN, props.get(Authenticator.PROPNAME_AUTH_TYPE));
     assertEquals("my-bearer-token", props.get(Authenticator.PROPNAME_BEARER_TOKEN));
+    assertNull(props.get(Authenticator.PROPNAME_SCOPE));
   }
 
   private void verifyMapService6(Map<String, String> props) {
@@ -724,6 +777,7 @@ public class CredentialUtilsTest {
     assertFalse(props.isEmpty());
     assertEquals("https://service6/api", props.get("URL"));
     assertEquals("my-bearer-token", props.get(Authenticator.PROPNAME_BEARER_TOKEN));
+    assertNull(props.get(Authenticator.PROPNAME_SCOPE));
   }
 
   private void verifyMapService7(Map<String, String> props) {
@@ -734,6 +788,16 @@ public class CredentialUtilsTest {
     assertEquals("==my-client-secret==", props.get(Authenticator.PROPNAME_CLIENT_SECRET));
     assertEquals("somefake========id", props.get(Authenticator.PROPNAME_CLIENT_ID));
     assertEquals("https://iamhost/iam/api=", props.get(Authenticator.PROPNAME_URL));
+    assertNull(props.get(Authenticator.PROPNAME_DISABLE_SSL));
+    assertNull(props.get(Authenticator.PROPNAME_SCOPE));
+  }
+
+  private void verifyMapService8(Map<String, String> props) {
+    assertNotNull(props);
+    assertFalse(props.isEmpty());
+    assertEquals(Authenticator.AUTHTYPE_IAM, props.get(Authenticator.PROPNAME_AUTH_TYPE));
+    assertEquals("V4HXmoUtMjohnsnow=KotN", props.get(Authenticator.PROPNAME_APIKEY));
+    assertEquals("A B C D", props.get(Authenticator.PROPNAME_SCOPE));
     assertNull(props.get(Authenticator.PROPNAME_DISABLE_SSL));
   }
 }

--- a/src/test/resources/my-credentials.env
+++ b/src/test/resources/my-credentials.env
@@ -53,6 +53,11 @@ SERVICE_7_CLIENT_SECRET===my-client-secret==
 SERVICE_7_AUTH_URL=https://iamhost/iam/api=
 SERVICE_7_AUTH_DISABLE_SSL=
 
+# Service8 configured with IAM w/scope
+SERVICE_8_AUTH_TYPE=iam
+SERVICE_8_APIKEY=V4HXmoUtMjohnsnow=KotN
+SERVICE_8_SCOPE=A B C D
+
 # Error1 - missing APIKEY
 ERROR1_AUTH_TYPE=IAM
 


### PR DESCRIPTION
The IAM /identity/token (get token) operation supports an optional "scope" form parameter which can be used to obtain an IAM access token having a limited set of scopes in this it can be used.

This commit adds support for the "Scope" field within the IamAuthenticator class. If set, the value of this field is sent as the "scope" form param in the "get token" request body when obtaining an access token.

ref: https://github.ibm.com/arf/planning-sdk-squad/issues/2167