### PR TITLE
feat: add support for gzip request body compression and upgrade okhttp version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <checkstyle-plugin-version>3.0.0</checkstyle-plugin-version>
         <jacoco-plugin-version>0.8.3</jacoco-plugin-version>
         <compiler-plugin-version>3.8.0</compiler-plugin-version>
-        <okhttp3-version>3.14.9</okhttp3-version>
+        <okhttp3-version>4.9.0</okhttp3-version>
         <logback-version>1.2.3</logback-version>
         <guava-version>29.0-jre</guava-version>
         <gson-version>2.8.5</gson-version>

--- a/src/main/java/com/ibm/cloud/sdk/core/http/HttpClientSingleton.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/HttpClientSingleton.java
@@ -265,6 +265,30 @@ public class HttpClientSingleton {
   }
 
   /**
+   * Sets a new list of interceptors for the specified {@link OkHttpClient} instance by removing the specified
+   * interceptor and returns a new instance with the interceptors configured as requested.
+   *
+   * @param client the {@link OkHttpClient} instance to set the proxy authenticator on
+   * @param interceptorToRemove the class name of the interceptor to remove
+   * @return the new {@link OkHttpClient} instance with the new list of interceptors
+   */
+  private OkHttpClient reconfigureClientInterceptors(OkHttpClient client, String interceptorToRemove) {
+    OkHttpClient.Builder builder = client.newBuilder();
+
+    if (!builder.interceptors().isEmpty()) {
+      for (int i = 0; i < builder.interceptors().size(); i++) {
+        String currentInterceptor = builder.interceptors().get(i).getClass().getSimpleName();
+        if (currentInterceptor.equals(interceptorToRemove)) {
+          LOG.log(Level.INFO, "Removing interceptor" + currentInterceptor + " from http client instance.");
+          builder.interceptors().remove(i);
+        }
+      }
+    }
+
+    return builder.build();
+  }
+
+  /**
    * Creates a new {@link OkHttpClient} instance with a new {@link ServiceCookieJar}
    * and a default configuration.
    *
@@ -318,6 +342,7 @@ public class HttpClientSingleton {
                         , options.getMaxRetries()))
                 .build();
       }
+      client = reconfigureClientInterceptors(client, "GzipRequestInterceptor");
       if (options.shouldEnableGzipCompression()) {
         client = client.newBuilder()
                 .addInterceptor(new GzipRequestInterceptor())

--- a/src/main/java/com/ibm/cloud/sdk/core/http/HttpClientSingleton.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/HttpClientSingleton.java
@@ -15,6 +15,7 @@ package com.ibm.cloud.sdk.core.http;
 
 import com.ibm.cloud.sdk.core.http.HttpConfigOptions.LoggingLevel;
 import com.ibm.cloud.sdk.core.http.ratelimit.RateLimitInterceptor;
+import com.ibm.cloud.sdk.core.http.gzip.GzipRequestInterceptor;
 import com.ibm.cloud.sdk.core.service.BaseService;
 import com.ibm.cloud.sdk.core.service.security.DelegatingSSLSocketFactory;
 import okhttp3.Authenticator;
@@ -315,6 +316,11 @@ public class HttpClientSingleton {
                         options.getAuthenticator()
                         , options.getDefaultRetryInterval()
                         , options.getMaxRetries()))
+                .build();
+      }
+      if (options.shouldEnableGzipCompression()) {
+        client = client.newBuilder()
+                .addInterceptor(new GzipRequestInterceptor())
                 .build();
       }
     }

--- a/src/main/java/com/ibm/cloud/sdk/core/http/HttpConfigOptions.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/HttpConfigOptions.java
@@ -34,6 +34,7 @@ public class HttpConfigOptions {
   }
 
   private boolean disableSslVerification;
+  private boolean enableGzipCompression;
   private Proxy proxy;
   private Authenticator proxyAuthenticator;
   private LoggingLevel loggingLevel;
@@ -45,6 +46,10 @@ public class HttpConfigOptions {
 
   public boolean shouldDisableSslVerification() {
     return this.disableSslVerification;
+  }
+
+  public boolean shouldEnableGzipCompression() {
+    return this.enableGzipCompression;
   }
 
   public Proxy getProxy() {
@@ -73,6 +78,7 @@ public class HttpConfigOptions {
 
   public static class Builder {
     private boolean disableSslVerification;
+    private boolean enableGzipCompression;
     private Proxy proxy;
     private Authenticator proxyAuthenticator;
     private LoggingLevel loggingLevel;
@@ -95,6 +101,18 @@ public class HttpConfigOptions {
      */
     public Builder disableSslVerification(boolean disableSslVerification) {
       this.disableSslVerification = disableSslVerification;
+      return this;
+    }
+
+    /**
+     * Sets flag to enable gzip compression of request bodies during HTTP requests. This should ONLY be used if truly
+     * intended, as many webservers can't handle this.
+     *
+     * @param enableGzipCompression whether to disable SSL verification or not
+     * @return the builder
+     */
+    public Builder enableGzipCompression(boolean enableGzipCompression) {
+      this.enableGzipCompression = enableGzipCompression;
       return this;
     }
 
@@ -150,6 +168,7 @@ public class HttpConfigOptions {
 
   private HttpConfigOptions(Builder builder) {
     this.disableSslVerification = builder.disableSslVerification;
+    this.enableGzipCompression = builder.enableGzipCompression;
     this.proxy = builder.proxy;
     this.proxyAuthenticator = builder.proxyAuthenticator;
     this.loggingLevel = builder.loggingLevel;

--- a/src/main/java/com/ibm/cloud/sdk/core/http/HttpConfigOptions.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/HttpConfigOptions.java
@@ -34,7 +34,7 @@ public class HttpConfigOptions {
   }
 
   private boolean disableSslVerification;
-  private boolean enableGzipCompression;
+  private Boolean enableGzipCompression;
   private Proxy proxy;
   private Authenticator proxyAuthenticator;
   private LoggingLevel loggingLevel;
@@ -48,7 +48,7 @@ public class HttpConfigOptions {
     return this.disableSslVerification;
   }
 
-  public boolean shouldEnableGzipCompression() {
+  public Boolean getGzipCompression() {
     return this.enableGzipCompression;
   }
 
@@ -78,7 +78,7 @@ public class HttpConfigOptions {
 
   public static class Builder {
     private boolean disableSslVerification;
-    private boolean enableGzipCompression;
+    private Boolean enableGzipCompression;
     private Proxy proxy;
     private Authenticator proxyAuthenticator;
     private LoggingLevel loggingLevel;
@@ -111,7 +111,7 @@ public class HttpConfigOptions {
      * @param enableGzipCompression whether to disable SSL verification or not
      * @return the builder
      */
-    public Builder enableGzipCompression(boolean enableGzipCompression) {
+    public Builder enableGzipCompression(Boolean enableGzipCompression) {
       this.enableGzipCompression = enableGzipCompression;
       return this;
     }

--- a/src/main/java/com/ibm/cloud/sdk/core/http/gzip/GzipRequestInterceptor.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/gzip/GzipRequestInterceptor.java
@@ -1,3 +1,15 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2020.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.ibm.cloud.sdk.core.http.gzip;
 
 import java.io.IOException;
@@ -10,7 +22,9 @@ import okio.BufferedSink;
 import okio.GzipSink;
 import okio.Okio;
 
-/** This interceptor compresses the HTTP request body. Many webservers can't handle this! */
+/** This interceptor compresses the HTTP request body. Many webservers can't handle this! For more information,
+ * and the original source code, please see https://square.github.io/okhttp/interceptors/#rewriting-requests.
+ */
 public final class GzipRequestInterceptor implements Interceptor {
     @Override public Response intercept(Interceptor.Chain chain) throws IOException {
       Request originalRequest = chain.request();

--- a/src/main/java/com/ibm/cloud/sdk/core/http/gzip/GzipRequestInterceptor.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/gzip/GzipRequestInterceptor.java
@@ -1,0 +1,45 @@
+package com.ibm.cloud.sdk.core.http.gzip;
+
+import java.io.IOException;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okio.BufferedSink;
+import okio.GzipSink;
+import okio.Okio;
+
+/** This interceptor compresses the HTTP request body. Many webservers can't handle this! */
+public final class GzipRequestInterceptor implements Interceptor {
+    @Override public Response intercept(Interceptor.Chain chain) throws IOException {
+      Request originalRequest = chain.request();
+      if (originalRequest.body() == null || originalRequest.header("Content-Encoding") != null) {
+        return chain.proceed(originalRequest);
+      }
+
+      Request compressedRequest = originalRequest.newBuilder()
+          .header("Content-Encoding", "gzip")
+          .method(originalRequest.method(), gzip(originalRequest.body()))
+          .build();
+      return chain.proceed(compressedRequest);
+    }
+
+    private RequestBody gzip(final RequestBody body) {
+      return new RequestBody() {
+        @Override public MediaType contentType() {
+          return body.contentType();
+        }
+
+        @Override public long contentLength() {
+          return -1; // We don't know the compressed length in advance!
+        }
+
+        @Override public void writeTo(BufferedSink sink) throws IOException {
+          BufferedSink gzipSink = Okio.buffer(new GzipSink(sink));
+          body.writeTo(gzipSink);
+          gzipSink.close();
+        }
+      };
+    }
+  }

--- a/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
@@ -128,7 +128,7 @@ public abstract class BaseService {
     // Check to see if "enable gzip" was set in the service properties.
     Boolean enableGzipCompression = Boolean.valueOf(props.get(PROPNAME_ENABLE_GZIP));
     if (enableGzipCompression) {
-      enableGzipCompression(true);
+      enableGzipCompression(enableGzipCompression);
     }
   }
 

--- a/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
@@ -60,6 +60,7 @@ import javax.net.ssl.SSLHandshakeException;
 public abstract class BaseService {
   public static final String PROPNAME_URL = "URL";
   public static final String PROPNAME_DISABLE_SSL = "DISABLE_SSL";
+  public static final String PROPNAME_ENABLE_GZIP = "ENABLE_GZIP";
 
   private static final Logger LOG = Logger.getLogger(BaseService.class.getName());
 
@@ -124,7 +125,25 @@ public abstract class BaseService {
           .build();
       this.configureClient(options);
     }
+    // Check to see if "enable gzip" was set in the service properties.
+    Boolean enableGzipCompression = Boolean.valueOf(props.get(PROPNAME_ENABLE_GZIP));
+    if (enableGzipCompression) {
+      enableGzipCompression(true);
+    }
   }
+
+  /**
+   * Enables gzip compression of requests bodies for the current client. If shouldEnableCompression
+   * is true, then a new client is configured with the GzipRequestInterceptor.
+   *
+   * @param shouldEnableCompression the value used to set the enableGzipCompression HttpConfigOption
+   */
+  public void enableGzipCompression(boolean shouldEnableCompression) {
+    HttpConfigOptions options = new HttpConfigOptions.Builder()
+        .enableGzipCompression(shouldEnableCompression)
+        .build();
+    this.configureClient(options);
+}
 
   /**
    * Returns the currently-configured {@link OkHttpClient} instance.

--- a/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
@@ -126,8 +126,9 @@ public abstract class BaseService {
       this.configureClient(options);
     }
     // Check to see if "enable gzip" was set in the service properties.
-    Boolean enableGzipCompression = Boolean.valueOf(props.get(PROPNAME_ENABLE_GZIP));
-    if (enableGzipCompression) {
+    String s = props.get(PROPNAME_ENABLE_GZIP);
+    if (StringUtils.isNotEmpty(s)) {
+      Boolean enableGzipCompression = Boolean.valueOf(s);
       enableGzipCompression(enableGzipCompression);
     }
   }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/http/HttpConfigTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/http/HttpConfigTest.java
@@ -27,7 +27,7 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 /**
  * Unit tests for the HttpConfigOptions object.
@@ -54,7 +54,7 @@ public class HttpConfigTest {
 
     assertEquals(true, configOptions.shouldDisableSslVerification());
     assertEquals(authenticator, configOptions.getProxyAuthenticator());
-    assertFalse(configOptions.shouldEnableGzipCompression());
+    assertNull(configOptions.getGzipCompression());
     assertEquals(proxy, configOptions.getProxy());
     assertEquals(HttpConfigOptions.LoggingLevel.HEADERS, configOptions.getLoggingLevel());
   }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/http/HttpConfigTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/http/HttpConfigTest.java
@@ -27,6 +27,7 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Unit tests for the HttpConfigOptions object.
@@ -53,6 +54,7 @@ public class HttpConfigTest {
 
     assertEquals(true, configOptions.shouldDisableSslVerification());
     assertEquals(authenticator, configOptions.getProxyAuthenticator());
+    assertFalse(configOptions.shouldEnableGzipCompression());
     assertEquals(proxy, configOptions.getProxy());
     assertEquals(HttpConfigOptions.LoggingLevel.HEADERS, configOptions.getLoggingLevel());
   }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/http/gzip/GzipTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/http/gzip/GzipTest.java
@@ -1,0 +1,824 @@
+package com.ibm.cloud.sdk.core.test.http.gzip;
+
+import com.google.gson.JsonObject;
+import com.ibm.cloud.sdk.core.http.HttpConfigOptions;
+import com.ibm.cloud.sdk.core.http.HttpMediaType;
+import com.ibm.cloud.sdk.core.http.RequestBuilder;
+import com.ibm.cloud.sdk.core.http.Response;
+import com.ibm.cloud.sdk.core.http.ServiceCall;
+import com.ibm.cloud.sdk.core.security.Authenticator;
+import com.ibm.cloud.sdk.core.security.NoAuthAuthenticator;
+import com.ibm.cloud.sdk.core.service.BaseService;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+import com.ibm.cloud.sdk.core.test.BaseServiceUnitTest;
+import com.ibm.cloud.sdk.core.util.ResponseConverterUtils;
+import okhttp3.HttpUrl;
+import okhttp3.MultipartBody;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import okio.Buffer;
+import okio.BufferedSink;
+import okio.GzipSink;
+import okio.Okio;
+
+import org.junit.Test;
+
+import static com.ibm.cloud.sdk.core.http.HttpHeaders.CONTENT_ENCODING;
+import static com.ibm.cloud.sdk.core.http.HttpHeaders.CONTENT_TYPE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.zip.GZIPInputStream;
+
+public class GzipTest extends BaseServiceUnitTest {
+
+	public class TestModel extends GenericModel {
+        String success;
+
+        public String getSuccess() {
+            return success;
+        }
+
+        public void setSuccess(String message) {
+            this.success = message;
+        }
+    }
+
+
+    public class TestService extends BaseService {
+
+        private static final String SERVICE_NAME = "test";
+
+        TestService(Authenticator auth) {
+            super(SERVICE_NAME, auth);
+        }
+
+        ServiceCall<TestModel> testMethod(RequestBuilder builder) {
+            return createServiceCall(builder.build(), ResponseConverterUtils.getObject(TestModel.class));
+        }
+
+        ServiceCall<Void> testMethodVoid(RequestBuilder builder) {
+            return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
+        }
+    }
+
+    private GzipTest.TestService service;
+
+    public void setUp(boolean enableGzip, boolean enableRateLimit) throws Exception {
+        super.setUp();
+        service = new GzipTest.TestService(new NoAuthAuthenticator());
+
+        HttpConfigOptions.Builder builder = new HttpConfigOptions.Builder();
+        if (enableGzip) {
+            builder.enableGzipCompression(true);
+        }
+        if (enableRateLimit) {
+            builder.enableRateLimitRetry(new NoAuthAuthenticator(),1,3);
+        }
+        service.configureClient(builder.build());
+        service.setServiceUrl(getMockWebServerUrl());
+    }
+    
+    private Buffer gzip(String data) throws IOException {
+        Buffer result = new Buffer();
+        BufferedSink sink = Okio.buffer(new GzipSink(result));
+        sink.writeUtf8(data);
+        sink.close();
+        return result;
+    }
+
+    private String ungzipRequestBody(Buffer requestBody) {
+        String body = null;
+        String charset = "UTF-8";
+        try (
+            InputStream gzippedResponse = requestBody.inputStream();
+            InputStream ungzippedResponse = new GZIPInputStream(gzippedResponse);
+            Reader reader = new InputStreamReader(ungzippedResponse, charset);
+            Writer writer = new StringWriter();
+        ) {
+            char[] buffer = new char[10240];
+            for (int length; (length = reader.read(buffer)) > 0; ) {
+                writer.write(buffer, 0, length);
+            }
+            body = writer.toString();
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return body;
+    }
+
+    @Test
+    public void testCompressionDisabledWithBodyJsonObjectPost() throws Throwable {
+        boolean enableGzip = false;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        final TestModel model = new TestModel();
+        model.setSuccess("awesome");
+    
+        final JsonObject contentJson = new JsonObject();
+        contentJson.addProperty("success", model.getSuccess());
+    
+        final RequestBuilder builder = RequestBuilder.post(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.header("Accept", "application/json");
+        builder.bodyJson(contentJson).build();
+
+        // queue the response to the mock server
+        String mockResponseBody = contentJson.toString();
+        server.enqueue(new MockResponse()
+            .setResponseCode(201)
+            .setBody(mockResponseBody)
+            .setHeader("Content-type", "application/json"));
+        
+        int bodySize = contentJson.toString().length();
+
+        // validate response
+        Response<TestModel> response = service.testMethod(builder).execute();
+        assertNotNull(response);
+        TestModel responseObj = response.getResult();
+        assertNotNull(responseObj);
+        assertEquals(201, response.getStatusCode());
+        assertEquals("awesome", responseObj.getSuccess());
+    
+        // Verify the request was indeed compressed, content encoding, & content length
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "POST");
+        assertNull(request.getHeader(CONTENT_ENCODING));
+        assertEquals(bodySize, request.getBodySize());
+        // Request should not be compressed
+        assertEquals(contentJson.toString(), request.getBody().readUtf8());
+    }
+	
+    @Test
+    public void testCompressionWithBodyJsonObjectPost() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        final TestModel model = new TestModel();
+        model.setSuccess("awesome");
+    
+        final JsonObject contentJson = new JsonObject();
+        contentJson.addProperty("success", model.getSuccess());
+    
+        final RequestBuilder builder = RequestBuilder.post(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.header("Accept", "application/json");
+        builder.bodyJson(contentJson).build();
+
+        // queue the response to the mock server
+        String mockResponseBody = contentJson.toString();
+        server.enqueue(new MockResponse()
+            .setResponseCode(201)
+            .setBody(mockResponseBody)
+            .setHeader("Content-type", "application/json"));
+
+        // the expected compressed request body
+        Buffer gzippedBody = gzip(contentJson.toString());
+        long bodySize = gzippedBody.size();
+
+        // validate response
+        Response<TestModel> response = service.testMethod(builder).execute();
+        assertNotNull(response);
+        TestModel responseObj = response.getResult();
+        assertNotNull(responseObj);
+        assertEquals(201, response.getStatusCode());
+        assertEquals("awesome", responseObj.getSuccess());
+    
+        // Verify the request was indeed compressed, content encoding, & content length
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "POST");
+        assertEquals("gzip", request.getHeader(CONTENT_ENCODING));
+        assertEquals(bodySize, request.getBodySize());
+        // Uncompress the request body and validate
+        assertEquals(mockResponseBody, ungzipRequestBody(request.getBody()));
+    }
+
+    @Test
+    public void testCompressionWithBodyJsonObjectPut() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        final TestModel model = new TestModel();
+        model.setSuccess("awesome");
+    
+        final JsonObject contentJson = new JsonObject();
+        contentJson.addProperty("success", model.getSuccess());
+    
+        final RequestBuilder builder = RequestBuilder.put(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.header("Accept", "application/json");
+        builder.bodyJson(contentJson).build();
+
+        // queue the response to the mock server
+        String mockResponseBody = contentJson.toString();
+        server.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody(mockResponseBody)
+            .setHeader("Content-type", "application/json"));
+
+        // the expected compressed request body
+        Buffer gzippedBody = gzip(contentJson.toString());
+        long bodySize = gzippedBody.size();
+
+        // validate response
+        Response<TestModel> response = service.testMethod(builder).execute();
+        assertNotNull(response);
+        TestModel responseObj = response.getResult();
+        assertNotNull(responseObj);
+        assertEquals(200, response.getStatusCode());
+        assertEquals("awesome", responseObj.getSuccess());
+    
+        // Verify the request was indeed compressed, content encoding, & content length
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "PUT");
+        assertEquals("gzip", request.getHeader(CONTENT_ENCODING));
+        assertEquals(bodySize, request.getBodySize());
+        // Uncompress the request body and validate
+        assertEquals(mockResponseBody, ungzipRequestBody(request.getBody()));
+    }
+
+    @Test
+    public void testCompressionWithBodyJsonObjectGet() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        final RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+
+        // queue the response to the mock server
+        String mockResponseBody = "{\"success\": \"awesome\"}";
+        server.enqueue(new MockResponse()
+            .setHeader("Content-type", "application/json")
+            .setResponseCode(200)
+            .setBody(mockResponseBody));
+
+        // validate response
+        Response<TestModel> response = service.testMethod(builder).execute();
+        assertNotNull(response);
+        TestModel responseObj = response.getResult();
+        assertNotNull(responseObj);
+        assertEquals(200, response.getStatusCode());
+        assertEquals("awesome", responseObj.getSuccess());
+    
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "GET");
+        assertNull(request.getHeader(CONTENT_ENCODING));
+        assertEquals(0, request.getBodySize());
+    }
+
+    @Test
+    public void testCompressionWithBodyJsonObjectHead() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        final RequestBuilder builder = RequestBuilder.head(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+
+        // queue the response to the mock server
+        server.enqueue(new MockResponse()
+            .setHeader("Content-type", "application/json")
+            .setResponseCode(200));
+
+        // validate response
+        Response<TestModel> response = service.testMethod(builder).execute();
+        assertNotNull(response);
+        TestModel responseObj = response.getResult();
+        assertNull(responseObj);
+        assertEquals(200, response.getStatusCode());
+    
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "HEAD");
+        assertNull(request.getHeader(CONTENT_ENCODING));
+        assertEquals(0, request.getBodySize());
+    }
+
+    @Test
+    public void testCompressionWithBodyOctetStreamPost() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        final String mockPayload = "This is a mock file.";
+        final InputStream payload = new ByteArrayInputStream(mockPayload.getBytes());
+        final RequestBuilder builder = RequestBuilder.post(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.bodyContent(payload, "application/octet-stream").build();
+
+        // queue the response to the mock server
+        server.enqueue(new MockResponse()
+            .setResponseCode(201)
+            .setHeader("Content-type", "application/octet-stream"));
+
+        // validate response
+        Response<Void> response = service.testMethodVoid(builder).execute();
+        assertNotNull(response);
+        Void responseObj = response.getResult();
+        assertNull(responseObj);
+        assertEquals(201, response.getStatusCode());
+    
+        // Verify the request
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "POST");
+        assertEquals("gzip", request.getHeader(CONTENT_ENCODING));
+        assertTrue(request.getBodySize() > 0);
+        // Uncompress the request body and validate
+        assertEquals(mockPayload, ungzipRequestBody(request.getBody()));
+    }
+
+    @Test
+    public void testCompressionWithBodyOctetStreamPut() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        final String mockPayload = "This is a mock file.";
+        final InputStream payload = new ByteArrayInputStream(mockPayload.getBytes());
+        final RequestBuilder builder = RequestBuilder.put(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.bodyContent(payload, "application/octet-stream").build();
+
+        // queue the response to the mock server
+        server.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setHeader("Content-type", "application/octet-stream"));
+
+        // validate response
+        Response<Void> response = service.testMethodVoid(builder).execute();
+        assertNotNull(response);
+        Void responseObj = response.getResult();
+        assertNull(responseObj);
+        assertEquals(200, response.getStatusCode());
+    
+        // Verify the request
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "PUT");
+        assertEquals("gzip", request.getHeader(CONTENT_ENCODING));
+        assertTrue(request.getBodySize() > 0);
+        // Uncompress the request body and validate
+        assertEquals(mockPayload, ungzipRequestBody(request.getBody()));
+    }
+
+    @Test
+    public void testCompressionWithBodyTextPlainPost() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        final String payload = "This is a mock payload.";
+        final RequestBuilder builder = RequestBuilder.post(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.bodyContent(payload, "text/plain").build();
+
+        // queue the response to the mock server
+        String mockResponseBody = "";
+        server.enqueue(new MockResponse()
+            .setResponseCode(201)
+            .setBody(mockResponseBody)
+            .setHeader("Content-type", "text/plain"));
+
+        // the expected compressed request body
+        Buffer gzippedBody = gzip(payload.toString());
+        long bodySize = gzippedBody.size();
+
+        // validate response
+        Response<Void> response = service.testMethodVoid(builder).execute();
+        assertNotNull(response);
+        Void responseObj = response.getResult();
+        assertNull(responseObj);
+        assertEquals(201, response.getStatusCode());
+
+    
+        // Verify the request
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "POST");
+        assertEquals("gzip", request.getHeader(CONTENT_ENCODING));
+        assertEquals(bodySize, request.getBodySize());
+        // Uncompress the request body and validate
+        assertEquals(payload, ungzipRequestBody(request.getBody()));
+    }
+
+    @Test
+    public void testCompressionWithBodyTextPlainPut() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        final String payload = "This is a mock payload.";
+        final RequestBuilder builder = RequestBuilder.put(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.bodyContent(payload, "text/plain").build();
+
+        // queue the response to the mock server
+        String mockResponseBody = "";
+        server.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody(mockResponseBody)
+            .setHeader("Content-type", "text/plain"));
+
+        // the expected compressed request body
+        Buffer gzippedBody = gzip(payload.toString());
+        long bodySize = gzippedBody.size();
+
+        // validate response
+        Response<Void> response = service.testMethodVoid(builder).execute();
+        assertNotNull(response);
+        Void responseObj = response.getResult();
+        assertNull(responseObj);
+        assertEquals(200, response.getStatusCode());
+
+    
+        // Verify the request
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "PUT");
+        assertEquals("gzip", request.getHeader(CONTENT_ENCODING));
+        assertEquals(bodySize, request.getBodySize());
+        // Uncompress the request body and validate
+        assertEquals(payload, ungzipRequestBody(request.getBody()));
+    }
+
+    @Test
+    public void testCompressionWithBodyTextHtmlPost() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        final String payload = "This is a mock payload.";
+        final RequestBuilder builder = RequestBuilder.post(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.bodyContent(payload, "text/html").build();
+
+        // queue the response to the mock server
+        String mockResponseBody = "";
+        server.enqueue(new MockResponse()
+            .setResponseCode(201)
+            .setBody(mockResponseBody)
+            .setHeader("Content-type", "text/html"));
+
+        // the expected compressed request body
+        Buffer gzippedBody = gzip(payload.toString());
+        long bodySize = gzippedBody.size();
+
+        // validate response
+        Response<Void> response = service.testMethodVoid(builder).execute();
+        assertNotNull(response);
+        Void responseObj = response.getResult();
+        assertNull(responseObj);
+        assertEquals(201, response.getStatusCode());
+
+    
+        // Verify the request
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "POST");
+        assertEquals("gzip", request.getHeader(CONTENT_ENCODING));
+        assertEquals(bodySize, request.getBodySize());
+        // Uncompress the request body and validate
+        assertEquals(payload, ungzipRequestBody(request.getBody()));
+    }
+
+    @Test
+    public void testCompressionWithBodyTextHtmlPut() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        final String payload = "This is a mock payload.";
+        final RequestBuilder builder = RequestBuilder.put(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.bodyContent(payload, "text/html").build();
+
+        // queue the response to the mock server
+        String mockResponseBody = "";
+        server.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody(mockResponseBody)
+            .setHeader("Content-type", "text/html"));
+
+        // the expected compressed request body
+        Buffer gzippedBody = gzip(payload.toString());
+        long bodySize = gzippedBody.size();
+
+        // validate response
+        Response<Void> response = service.testMethodVoid(builder).execute();
+        assertNotNull(response);
+        Void responseObj = response.getResult();
+        assertNull(responseObj);
+        assertEquals(200, response.getStatusCode());
+
+    
+        // Verify the request
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "PUT");
+        assertEquals("gzip", request.getHeader(CONTENT_ENCODING));
+        assertEquals(bodySize, request.getBodySize());
+        // Uncompress the request body and validate
+        assertEquals(payload, ungzipRequestBody(request.getBody()));
+    }
+
+    @Test
+    public void testCompressionWithBodyMultiPartFormPost() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        MultipartBody.Builder multipartBuilder = new MultipartBody.Builder();
+        multipartBuilder.setType(MultipartBody.FORM);
+        final String payload = "This is a mock payload.";
+        multipartBuilder.addFormDataPart("string_prop", payload);
+        final RequestBuilder builder = RequestBuilder.post(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.body(multipartBuilder.build());
+
+        // queue the response to the mock server
+        String mockResponseBody = "";
+        server.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody(mockResponseBody)
+            .setHeader("Content-type", "multipart/form-data"));
+
+        // validate response
+        Response<Void> response = service.testMethodVoid(builder).execute();
+        assertNotNull(response);
+        Void responseObj = response.getResult();
+        assertNull(responseObj);
+        assertEquals(200, response.getStatusCode());
+
+    
+        // Verify the request
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "POST");
+        assertEquals("gzip", request.getHeader(CONTENT_ENCODING));
+    }
+
+    @Test
+    public void testCompressionWithBodyMultiPartFormPut() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        MultipartBody.Builder multipartBuilder = new MultipartBody.Builder();
+        multipartBuilder.setType(MultipartBody.FORM);
+        final String payload = "This is a mock payload.";
+        multipartBuilder.addFormDataPart("string_prop", payload);
+        final RequestBuilder builder = RequestBuilder.put(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.body(multipartBuilder.build());
+
+        // queue the response to the mock server
+        String mockResponseBody = "";
+        server.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody(mockResponseBody)
+            .setHeader("Content-type", "multipart/form-data"));
+
+        // validate response
+        Response<Void> response = service.testMethodVoid(builder).execute();
+        assertNotNull(response);
+        Void responseObj = response.getResult();
+        assertNull(responseObj);
+        assertEquals(200, response.getStatusCode());
+
+    
+        // Verify the request
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "PUT");
+        assertEquals("gzip", request.getHeader(CONTENT_ENCODING));
+    }
+
+    @Test
+    public void testShouldNotGzipCompressWithBodyJsonObject() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        final TestModel model = new TestModel();
+        model.setSuccess("awesome");
+    
+        final JsonObject contentJson = new JsonObject();
+        contentJson.addProperty("success", model.getSuccess());
+    
+        final RequestBuilder builder = RequestBuilder.post(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.header("Accept", "application/json");
+        builder.header("Content-Encoding", "deflate");
+        builder.bodyJson(contentJson).build();
+
+        // queue the response to the mock server
+        String mockResponseBody = contentJson.toString();
+        server.enqueue(new MockResponse()
+            .setResponseCode(201)
+            .setBody(mockResponseBody)
+            .setHeader("Content-type", "application/json"));
+
+        // validate response
+        Response<TestModel> response = service.testMethod(builder).execute();
+        assertNotNull(response);
+        TestModel responseObj = response.getResult();
+        assertNotNull(responseObj);
+        assertEquals(201, response.getStatusCode());
+        assertEquals("awesome", responseObj.getSuccess());
+    
+        // Verify the request was not compressed
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "POST");
+        assertEquals("deflate", request.getHeader(CONTENT_ENCODING));
+        assertEquals(mockResponseBody.length(), request.getBodySize());
+    }
+
+    @Test
+    public void testShouldNotGzipCompressBodyOctetStreamPost() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        final String mockPayload = "This is a mock file.";
+        final InputStream payload = new ByteArrayInputStream(mockPayload.getBytes());
+        final RequestBuilder builder = RequestBuilder.post(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.header("Content-Encoding", "deflate");
+        builder.bodyContent(payload, "application/octet-stream").build();
+
+        // queue the response to the mock server
+        server.enqueue(new MockResponse()
+            .setResponseCode(201)
+            .setHeader("Content-type", "application/octet-stream"));
+
+        // validate response
+        Response<Void> response = service.testMethodVoid(builder).execute();
+        assertNotNull(response);
+        Void responseObj = response.getResult();
+        assertNull(responseObj);
+        assertEquals(201, response.getStatusCode());
+    
+        // Verify the request was not compressed
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertTrue(request.getBodySize() > 0);
+        assertEquals(request.getMethod(), "POST");
+        assertEquals("deflate", request.getHeader(CONTENT_ENCODING));
+    }
+
+    @Test
+    public void testShouldNotGzipCompressBodyTextPlainPost() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        final String payload = "This is a mock payload.";
+        final RequestBuilder builder = RequestBuilder.post(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.header("Content-Encoding", "deflate");
+        builder.bodyContent(payload, "text/plain").build();
+
+        // queue the response to the mock server
+        String mockResponseBody = "";
+        server.enqueue(new MockResponse()
+            .setResponseCode(201)
+            .setBody(mockResponseBody)
+            .setHeader("Content-type", "text/plain"));
+
+        // validate response
+        Response<Void> response = service.testMethodVoid(builder).execute();
+        assertNotNull(response);
+        Void responseObj = response.getResult();
+        assertNull(responseObj);
+        assertEquals(201, response.getStatusCode());
+
+    
+        // Verify the request was not compressed
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "POST");
+        assertEquals("deflate", request.getHeader(CONTENT_ENCODING));
+        assertEquals(payload.length(), request.getBodySize());
+    }
+
+    @Test
+    public void testShouldNotGzipCompressBodyTextHtmlPost() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        final String payload = "This is a mock payload.";
+        final RequestBuilder builder = RequestBuilder.post(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.header("Content-Encoding", "deflate");
+        builder.bodyContent(payload, "text/html").build();
+
+        // queue the response to the mock server
+        String mockResponseBody = "";
+        server.enqueue(new MockResponse()
+            .setResponseCode(201)
+            .setBody(mockResponseBody)
+            .setHeader("Content-type", "text/html"));
+
+        // validate response
+        Response<Void> response = service.testMethodVoid(builder).execute();
+        assertNotNull(response);
+        Void responseObj = response.getResult();
+        assertNull(responseObj);
+        assertEquals(201, response.getStatusCode());
+
+    
+        // Verify the request was not compressed
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "POST");
+        assertEquals("deflate", request.getHeader(CONTENT_ENCODING));
+        assertEquals(payload.length(), request.getBodySize());
+    }
+
+    @Test
+    public void testShouldNotGzipCompressBodyMultiPartFormPost() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = false;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        MultipartBody.Builder multipartBuilder = new MultipartBody.Builder();
+        multipartBuilder.setType(MultipartBody.FORM);
+        final String payload = "This is a mock payload.";
+        multipartBuilder.addFormDataPart("string_prop", payload);
+        final RequestBuilder builder = RequestBuilder.post(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.header("Content-Encoding", "deflate");
+        builder.body(multipartBuilder.build());
+
+        // queue the response to the mock server
+        String mockResponseBody = "";
+        server.enqueue(new MockResponse()
+            .setResponseCode(201)
+            .setBody(mockResponseBody)
+            .setHeader("Content-type", "multipart/form-data"));
+
+        // validate response
+        Response<Void> response = service.testMethodVoid(builder).execute();
+        assertNotNull(response);
+        Void responseObj = response.getResult();
+        assertNull(responseObj);
+        assertEquals(201, response.getStatusCode());
+
+    
+        // Verify the request was not compressed
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "POST");
+        assertEquals("deflate", request.getHeader(CONTENT_ENCODING));
+    }
+
+    @Test
+    public void testRetrySuccessWithGzip() throws Throwable {
+        boolean enableGzip = true;
+        boolean enableRateLimit = true;
+        setUp(enableGzip, enableRateLimit);
+        // build the request
+        final String payload = "This is a mock payload.";
+        final RequestBuilder builder = RequestBuilder.post(HttpUrl.parse(service.getServiceUrl() + "/v1/test"));
+        builder.bodyContent(payload, "text/plain").build();
+    
+        String message = "The request failed because the moon is full.";
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(429)
+                .addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON)
+                .setBody("{\"error\": \"" + message + "\"}"));
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON)
+                .setBody("{\"success\": \"awesome\"}"));
+
+        // the expected compressed request body
+        Buffer gzippedBody = gzip(payload.toString());
+        long bodySize = gzippedBody.size();
+
+
+        Response<TestModel> r = service.testMethod(builder).execute();
+
+        assertEquals(200, r.getStatusCode());
+        assertEquals("awesome", r.getResult().getSuccess());
+        assertEquals(2, server.getRequestCount());
+
+        // Verify both requests were compressed
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "POST");
+        assertEquals("gzip", request.getHeader(CONTENT_ENCODING));
+        assertEquals(bodySize, request.getBodySize());
+        assertEquals(payload, ungzipRequestBody(request.getBody()));
+        request = server.takeRequest();
+        assertNotNull(request);
+        assertEquals(request.getMethod(), "POST");
+        assertEquals("gzip", request.getHeader(CONTENT_ENCODING));
+        assertEquals(bodySize, request.getBodySize());
+        assertEquals(payload, ungzipRequestBody(request.getBody()));
+    }
+}

--- a/src/test/java/com/ibm/cloud/sdk/core/test/http/ratelimit/RateLimitTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/http/ratelimit/RateLimitTest.java
@@ -17,12 +17,17 @@ import com.ibm.cloud.sdk.core.util.ResponseConverterUtils;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+
 import org.junit.Before;
 import org.junit.Test;
 
 import static com.ibm.cloud.sdk.core.http.HttpHeaders.CONTENT_TYPE;
+import static com.ibm.cloud.sdk.core.http.HttpHeaders.CONTENT_ENCODING;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 
 public class RateLimitTest extends BaseServiceUnitTest {
 
@@ -96,7 +101,7 @@ public class RateLimitTest extends BaseServiceUnitTest {
      * Test that we retry on 429
      */
     @Test
-    public void testRetrySuccess() {
+    public void testRetrySuccess() throws Throwable {
 
         String message = "The request failed because the moon is full.";
 
@@ -116,6 +121,9 @@ public class RateLimitTest extends BaseServiceUnitTest {
         assertEquals("awesome", r.getResult().getSuccess());
         assertEquals(2, server.getRequestCount());
 
+        RecordedRequest request = server.takeRequest();
+        assertNotNull(request);
+        assertNull(request.getHeader(CONTENT_ENCODING));
     }
 
     /**

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/ConfigureServiceTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/ConfigureServiceTest.java
@@ -119,6 +119,20 @@ public class ConfigureServiceTest {
        }
     }
     assertTrue(containsGzipInterceptor);
+
+    // Disable gzip and validate it was removed from the client
+    containsGzipInterceptor = false;
+    svc.enableGzipCompression(false);
+    client = svc.getClient();
+    assertNotNull(client);
+    interceptors = client.interceptors();
+  
+    for (Interceptor is: interceptors) {
+      if (is.getClass().equals(gzip.getClass())) {
+        containsGzipInterceptor = true;
+       }
+    }
+    assertFalse(containsGzipInterceptor);
     
   }
 

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/ConfigureServiceTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/ConfigureServiceTest.java
@@ -120,6 +120,16 @@ public class ConfigureServiceTest {
     }
     assertTrue(containsGzipInterceptor);
 
+    // Manually call enable gzip and confirm the interceptor is still present
+    svc.enableGzipCompression(true);
+    containsGzipInterceptor = false;
+    for (Interceptor is: interceptors) {
+      if (is.getClass().equals(gzip.getClass())) {
+        containsGzipInterceptor = true;
+       }
+    }
+    assertTrue(containsGzipInterceptor);
+
     // Disable gzip and validate it was removed from the client
     containsGzipInterceptor = false;
     svc.enableGzipCompression(false);
@@ -133,7 +143,112 @@ public class ConfigureServiceTest {
        }
     }
     assertFalse(containsGzipInterceptor);
-    
+  }
+
+  @Test
+  public void testConfigureServiceOnInitiationCredsGzipDisabled() {
+    PowerMockito.spy(EnvironmentUtils.class);
+    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    BasicAuthenticator auth = new BasicAuthenticator(BASIC_USERNAME, "password1");
+    TestServiceConfigured svc = new TestServiceConfigured("SERVICE_10", auth);
+    assertNull(svc.getServiceUrl());
+
+    // Confirm gzip was not enabled in the client
+    OkHttpClient client = svc.getClient();
+    assertNotNull(client);
+    List<Interceptor> interceptors = client.interceptors();
+    assertFalse(interceptors.size() > 0);
+
+    boolean containsGzipInterceptor = false;
+    GzipRequestInterceptor gzip = new GzipRequestInterceptor();
+
+    // Manually call enable gzip and confirm the interceptor is present
+    svc.enableGzipCompression(true);
+    containsGzipInterceptor = false;
+    client = svc.getClient();
+    interceptors = client.interceptors();
+    for (Interceptor is: interceptors) {
+      if (is.getClass().equals(gzip.getClass())) {
+        containsGzipInterceptor = true;
+       }
+    }
+    assertTrue(containsGzipInterceptor);
+  }
+
+  @Test
+  public void testConfigureServiceAfterInitiationCredsGzipEnabled() {
+    PowerMockito.spy(EnvironmentUtils.class);
+    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    BasicAuthenticator auth = new BasicAuthenticator(BASIC_USERNAME, "password1");
+    TestService svc = new TestService("SERVICE_1", auth);
+    assertNull(svc.getServiceUrl());
+
+    // Enable gzip
+    svc.enableGzipCompression(true);
+    OkHttpClient client = svc.getClient();
+    assertNotNull(client);
+    List<Interceptor> interceptors = client.interceptors();
+    assertTrue(interceptors.size() > 0);
+
+    boolean containsGzipInterceptor = false;
+    GzipRequestInterceptor gzip = new GzipRequestInterceptor();
+
+    for (Interceptor is: interceptors) {
+      if (is.getClass().equals(gzip.getClass())) {
+        containsGzipInterceptor = true;
+       }
+    }
+    assertTrue(containsGzipInterceptor);
+
+    // Manually call configureSvc and confirm gzip is still enabled
+    svc.configureSvc("SERVICE_1");
+    containsGzipInterceptor = false;
+    client = svc.getClient();
+    interceptors = client.interceptors();
+    for (Interceptor is: interceptors) {
+      if (is.getClass().equals(gzip.getClass())) {
+        containsGzipInterceptor = true;
+       }
+    }
+    assertTrue(containsGzipInterceptor);
+  }
+
+  @Test
+  public void testConfigureServiceAfterInitiationCredsGzipDisabled() {
+    PowerMockito.spy(EnvironmentUtils.class);
+    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    BasicAuthenticator auth = new BasicAuthenticator(BASIC_USERNAME, "password1");
+    TestService svc = new TestService("SERVICE_10", auth);
+    assertNull(svc.getServiceUrl());
+
+    // Enable gzip
+    svc.enableGzipCompression(true);
+    OkHttpClient client = svc.getClient();
+    assertNotNull(client);
+    List<Interceptor> interceptors = client.interceptors();
+    assertTrue(interceptors.size() > 0);
+
+    boolean containsGzipInterceptor = false;
+    GzipRequestInterceptor gzip = new GzipRequestInterceptor();
+
+    for (Interceptor is: interceptors) {
+      if (is.getClass().equals(gzip.getClass())) {
+        containsGzipInterceptor = true;
+       }
+    }
+    assertTrue(containsGzipInterceptor);
+
+    // Manually call configureSvc and confirm gzip was disabled
+    svc.configureSvc("SERVICE_10");
+    containsGzipInterceptor = false;
+    client = svc.getClient();
+    interceptors = client.interceptors();
+    for (Interceptor is: interceptors) {
+      if (is.getClass().equals(gzip.getClass())) {
+        containsGzipInterceptor = true;
+       }
+    }
+    assertFalse(containsGzipInterceptor);
   }
 
   @Test

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestTest.java
@@ -1,0 +1,124 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.sdk.core.test.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.gson.JsonObject;
+import com.ibm.cloud.sdk.core.http.RequestBuilder;
+import com.ibm.cloud.sdk.core.http.Response;
+import com.ibm.cloud.sdk.core.http.ServiceCall;
+import static com.ibm.cloud.sdk.core.http.HttpHeaders.CONTENT_ENCODING;
+import com.ibm.cloud.sdk.core.security.Authenticator;
+import com.ibm.cloud.sdk.core.security.IamAuthenticator;
+import com.ibm.cloud.sdk.core.security.IamToken;
+import com.ibm.cloud.sdk.core.service.BaseService;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+import com.ibm.cloud.sdk.core.test.BaseServiceUnitTest;
+import com.ibm.cloud.sdk.core.util.ResponseConverterUtils;
+import static com.ibm.cloud.sdk.core.test.TestUtils.loadFixture;
+
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+
+public class RequestTest extends BaseServiceUnitTest {
+  private class TestModel extends GenericModel {
+    String city;
+
+    public String getCity() {
+      return city;
+    }
+
+    public void setCity(String city) {
+      this.city = city;
+    }
+  }
+
+  public class TestService extends BaseService {
+
+    private static final String SERVICE_NAME = "test";
+
+    TestService(Authenticator auth) {
+      super(SERVICE_NAME, auth);
+    }
+
+    ServiceCall<TestModel> postTestModel() {
+      final TestModel model = new TestModel();
+      model.setCity("Columbus");
+    
+      final JsonObject contentJson = new JsonObject();
+      contentJson.addProperty("city", model.getCity());
+      RequestBuilder builder = RequestBuilder.post(HttpUrl.parse(getServiceUrl() + "/v1/test"));
+      builder.bodyJson(contentJson).build();
+      return createServiceCall(builder.build(), ResponseConverterUtils.getObject(TestModel.class));
+    }
+   
+  }
+
+  private TestService service;
+  private String testResponseValue = "Columbus";
+  private String testResponseBody1 = "{\"city\": \"Columbus\"}";
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+  }
+
+  @Test
+  public void testRequestIncludeAuthGzipEnabled() throws Throwable {
+    // setup the service & configure it with compression enabled
+    IamAuthenticator authenticator = new IamAuthenticator("API_KEY");
+    authenticator.setURL(getMockWebServerUrl());
+
+    service = new TestService(authenticator);
+    service.setServiceUrl(getMockWebServerUrl());
+    service.enableGzipCompression(true);
+
+    IamToken tokenData = null;
+    try {
+      tokenData = loadFixture("src/test/resources/iam_token.json", IamToken.class);
+    } catch (Exception e) {
+      fail(e.toString());
+    }
+    // the first response SHOULD just be the response from the call to authenticate()
+    // so queue that first
+    server.enqueue(jsonResponse(tokenData));
+    server.enqueue(new MockResponse().setBody(testResponseBody1));
+    // Validate the response
+    Response<TestModel> response = service.postTestModel().execute();
+    assertNotNull(response.getResult());
+    assertEquals(testResponseValue, response.getResult().getCity());
+    // Validate the first request wasn't compressed. This should be the call to authenticate()
+    String expectedAuthBody = "grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey&apikey=API_KEY&response_type=cloud_iam";
+    RecordedRequest request = server.takeRequest();
+    assertEquals(request.getMethod(), "POST");
+    assertEquals(expectedAuthBody, request.getBody().readUtf8());
+    assertNull(request.getHeader(CONTENT_ENCODING));
+    // Validate the next request was compressed, which should be the call to the service
+    String expectedOperationBody = "{\"city\": \"Columbus\"}";
+    request = server.takeRequest();
+    assertEquals("gzip", request.getHeader(CONTENT_ENCODING));
+    assertFalse(expectedOperationBody == request.getBody().readUtf8());
+    assertEquals(request.getMethod(), "POST");
+  }
+}

--- a/src/test/java/com/ibm/cloud/sdk/core/util/CredentialUtilsTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/CredentialUtilsTest.java
@@ -32,6 +32,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.ibm.cloud.sdk.core.security.Authenticator;
 import com.ibm.cloud.sdk.core.security.CloudPakForDataAuthenticator;
+import com.ibm.cloud.sdk.core.service.BaseService;
 import com.ibm.cloud.sdk.core.util.CredentialUtils;
 import com.ibm.cloud.sdk.core.util.EnvironmentUtils;
 
@@ -85,6 +86,12 @@ public class CredentialUtilsTest {
     env.put("SERVICE_8_AUTH_TYPE", Authenticator.AUTHTYPE_IAM);
     env.put("SERVICE_8_APIKEY", "V4HXmoUtMjohnsnow=KotN");
     env.put("SERVICE_8_SCOPE", "A B C D");
+    env.put("SERVICE_9_AUTH_TYPE", Authenticator.AUTHTYPE_IAM);
+    env.put("SERVICE_9_APIKEY", "my-api-key");
+    env.put("SERVICE_9_CLIENT_ID", "my-client-id");
+    env.put("SERVICE_9_CLIENT_SECRET", "my-client-secret");
+    env.put("SERVICE_9_AUTH_URL", "https://iamhost/iam/api");
+    env.put("SERVICE_9_ENABLE_GZIP", "true");
 
     return env;
   }
@@ -127,6 +134,12 @@ public class CredentialUtilsTest {
     System.setProperty("SERVICE_8_AUTH_TYPE", Authenticator.AUTHTYPE_IAM);
     System.setProperty("SERVICE_8_APIKEY", "V4HXmoUtMjohnsnow=KotN");
     System.setProperty("SERVICE_8_SCOPE", "A B C D");
+    System.setProperty("SERVICE_9_AUTH_TYPE", Authenticator.AUTHTYPE_IAM);
+    System.setProperty("SERVICE_9_APIKEY", "my-api-key");
+    System.setProperty("SERVICE_9_CLIENT_ID", "my-client-id");
+    System.setProperty("SERVICE_9_CLIENT_SECRET", "my-client-secret");
+    System.setProperty("SERVICE_9_AUTH_URL", "https://iamhost/iam/api");
+    System.setProperty("SERVICE_9_ENABLE_GZIP", "true");
   }
 
   private void clearTestSystemProps() {
@@ -167,6 +180,12 @@ public class CredentialUtilsTest {
     System.clearProperty("SERVICE_8_AUTH_TYPE");
     System.clearProperty("SERVICE_8_APIKEY");
     System.clearProperty("SERVICE_8_SCOPE");
+    System.clearProperty("SERVICE_9_AUTH_TYPE");
+    System.clearProperty("SERVICE_9_APIKEY");
+    System.clearProperty("SERVICE_9_CLIENT_ID");
+    System.clearProperty("SERVICE_9_CLIENT_SECRET");
+    System.clearProperty("SERVICE_9_AUTH_URL");
+    System.clearProperty("SERVICE_9_ENABLE_GZIP");
   }
 
   /**
@@ -310,6 +329,16 @@ public class CredentialUtilsTest {
   }
 
   @Test
+  public void testFileCredentialsMapService9() {
+    PowerMockito.spy(EnvironmentUtils.class);
+    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    assertEquals(ALTERNATE_CRED_FILENAME, EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE"));
+
+    Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service-9");
+    verifyMapService9(props);
+  }
+
+  @Test
   public void testFileCredentialsSystemPropEmpty() {
     System.setProperty("IBM_CREDENTIALS_FILE", "");
     Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service-1");
@@ -407,6 +436,17 @@ public class CredentialUtilsTest {
   }
 
   @Test
+  public void testFileCredentialsSystemPropService9() {
+    System.setProperty("IBM_CREDENTIALS_FILE", ALTERNATE_CRED_FILENAME);
+    assertEquals(ALTERNATE_CRED_FILENAME, System.getProperty("IBM_CREDENTIALS_FILE"));
+
+    Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service-9");
+    verifyMapService9(props);
+    System.clearProperty("IBM_CREDENTIALS_FILE");
+    assertNull(System.getProperty("IBM_CREDENTIALS_FILE"));
+  }
+
+  @Test
   public void testEnvCredentialsMapEmpty() {
     PowerMockito.spy(EnvironmentUtils.class);
     PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(new HashMap<String, String>());
@@ -484,6 +524,15 @@ public class CredentialUtilsTest {
 
     Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service-8");
     verifyMapService8(props);
+  }
+
+  @Test
+  public void testEnvCredentialsMapService9() {
+    PowerMockito.spy(EnvironmentUtils.class);
+    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+
+    Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service-9");
+    verifyMapService9(props);
   }
 
   @Test
@@ -567,6 +616,15 @@ public class CredentialUtilsTest {
 
     Map<String, String> props = CredentialUtils.getSystemPropsCredentialsAsMap("service-8");
     verifyMapService8(props);
+    clearTestSystemProps();
+  }
+
+  @Test
+  public void testSystemPropsCredentialsService9() {
+    setTestSystemProps();
+
+    Map<String, String> props = CredentialUtils.getSystemPropsCredentialsAsMap("service-9");
+    verifyMapService9(props);
     clearTestSystemProps();
   }
 
@@ -799,5 +857,17 @@ public class CredentialUtilsTest {
     assertEquals("V4HXmoUtMjohnsnow=KotN", props.get(Authenticator.PROPNAME_APIKEY));
     assertEquals("A B C D", props.get(Authenticator.PROPNAME_SCOPE));
     assertNull(props.get(Authenticator.PROPNAME_DISABLE_SSL));
+  }
+
+  private void verifyMapService9(Map<String, String> props) {
+    assertNotNull(props);
+    assertFalse(props.isEmpty());
+    assertEquals(Authenticator.AUTHTYPE_IAM, props.get(Authenticator.PROPNAME_AUTH_TYPE));
+    assertEquals("my-api-key", props.get(Authenticator.PROPNAME_APIKEY));
+    assertEquals("my-client-secret", props.get(Authenticator.PROPNAME_CLIENT_SECRET));
+    assertEquals("my-client-id", props.get(Authenticator.PROPNAME_CLIENT_ID));
+    assertEquals("https://iamhost/iam/api", props.get(Authenticator.PROPNAME_URL));
+    assertNull(props.get(Authenticator.PROPNAME_SCOPE));
+    assertEquals("true", props.get(BaseService.PROPNAME_ENABLE_GZIP));
   }
 }

--- a/src/test/resources/my-credentials.env
+++ b/src/test/resources/my-credentials.env
@@ -66,6 +66,14 @@ SERVICE_9_CLIENT_SECRET=my-client-secret
 SERVICE_9_AUTH_URL=https://iamhost/iam/api
 SERVICE_9_ENABLE_GZIP=true
 
+# Service9 configured with gzip disabled
+SERVICE_10_AUTH_TYPE=iam
+SERVICE_10_APIKEY=my-api-key
+SERVICE_10_CLIENT_ID=my-client-id
+SERVICE_10_CLIENT_SECRET=my-client-secret
+SERVICE_10_AUTH_URL=https://iamhost/iam/api
+SERVICE_10_ENABLE_GZIP=false
+
 # Error1 - missing APIKEY
 ERROR1_AUTH_TYPE=IAM
 

--- a/src/test/resources/my-credentials.env
+++ b/src/test/resources/my-credentials.env
@@ -58,6 +58,14 @@ SERVICE_8_AUTH_TYPE=iam
 SERVICE_8_APIKEY=V4HXmoUtMjohnsnow=KotN
 SERVICE_8_SCOPE=A B C D
 
+# Service9 configured with gzip enabled
+SERVICE_9_AUTH_TYPE=iam
+SERVICE_9_APIKEY=my-api-key
+SERVICE_9_CLIENT_ID=my-client-id
+SERVICE_9_CLIENT_SECRET=my-client-secret
+SERVICE_9_AUTH_URL=https://iamhost/iam/api
+SERVICE_9_ENABLE_GZIP=true
+
 # Error1 - missing APIKEY
 ERROR1_AUTH_TYPE=IAM
 


### PR DESCRIPTION
This PR adds support for compressing request bodies using gzip. A new ``enableGzipCompression`` method was added as part of the BaseService class, and is used to add the ``GzipRequestInterceptor`` to the instance of the Base Service's http client. This new interceptor sets the ``Content-Encoding`` of the request body to ``gzip``, if no ``Content-Encoding`` header exists and then compresses the request body.

**The version of okhttp was also upgraded to v4.9.0**

ref: https://github.ibm.com/arf/planning-sdk-squad/issues/2181