### PR TITLE
chore: upgrade common-codec dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <logback-version>1.2.3</logback-version>
         <guava-version>29.0-jre</guava-version>
         <gson-version>2.8.5</gson-version>
-        <commons-codec-version>1.12</commons-codec-version>
+        <commons-codec-version>1.13</commons-codec-version>
         <commons-io-version>2.6</commons-io-version>
         <commons-lang3-version>3.8.1</commons-lang3-version>
         <rx-version>2.2.7</rx-version>


### PR DESCRIPTION
This PR upgrades the `commons-codec` dependency to `1.13` to address a vulnerability discovered by Snyk.