### PR TITLE
feat: add new DateUtils utility class

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/util/DateDeserializer.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/DateDeserializer.java
@@ -19,8 +19,6 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -60,8 +58,6 @@ public class DateDeserializer implements JsonDeserializer<Date> {
 
   private final List<SimpleDateFormat> rfc822Formatters =
       Arrays.asList(rfc822DateFormatter, rfc822WithoutMsDateFormatter);
-
-  private static final Logger LOG = Logger.getLogger(DateDeserializer.class.getName());
 
   /*
    * (non-Javadoc)
@@ -113,8 +109,6 @@ public class DateDeserializer implements JsonDeserializer<Date> {
       return new Date(timeAsLong);
     }
 
-    LOG.log(Level.SEVERE, "Error parsing: " + dateAsString, e);
-    return null;
+    throw new JsonParseException("Error while de-serializing date: " + dateAsString, e);
   }
-
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/util/DateUtils.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/DateUtils.java
@@ -1,0 +1,92 @@
+/**
+ * (C) Copyright IBM Corp. 2020.  All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.sdk.core.util;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * This class contains utilities for formatting java.util.Date instances as a
+ * "date" or a "date-time" value. In this context, "date" and "date-time" refer
+ * to the data and datetime types that are part of the OpenAPI Specification.
+ */
+public class DateUtils {
+  private static final SimpleDateFormat rfc3339FullDateFormatter = new SimpleDateFormat("yyyy-MM-dd");
+  private static final SimpleDateFormat utcDateTimeFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+
+  // Hide the ctor since this is a utility class.
+  private DateUtils() {
+  }
+
+  /**
+   * Formats the specified Date value as an OpenAPI "date"
+   * (a string of the form "yyyy-MM-dd").
+   *
+   * @param d the Date instance to be formatted
+   * @return a string representing an OpenAPI "date" (yyyy-MM-dd).
+   */
+  public static String formatAsDate(Date d) {
+    String s;
+    synchronized (rfc3339FullDateFormatter) {
+      s = rfc3339FullDateFormatter.format(d);
+    }
+    return s;
+  }
+
+  /**
+   * Parses the specified string (assumed to be of the form yyyy-MM-dd) as a Date value.
+   *
+   * @param s the string to be parsed
+   * @return the resulting Date value
+   * @throws ParseException error during parsing
+   */
+  public static Date parseAsDate(String s) throws ParseException {
+    Date d;
+    synchronized (rfc3339FullDateFormatter) {
+      d = rfc3339FullDateFormatter.parse(s);
+    }
+    return d;
+  }
+
+  /**
+   * Formats the specified Date value as an OpenAPI "date-time"
+   * (a string of the form "yyyy-MM-dd'T'HH:mm:ss.SSS").
+   *
+   * @param d the Date instance to be formatted
+   * @return a string representing an OpenAPI "date-time" (yyyy-MM-dd'T'HH:mm:ss.SSS).
+   */
+  public static String formatAsDateTime(Date d) {
+    String s;
+    synchronized (utcDateTimeFormatter) {
+      s = utcDateTimeFormatter.format(d);
+    }
+    return s;
+  }
+
+  /**
+   * Parses the specified string (assumed to be of the form yyyy-MM-dd'T'HH:mm:ss.SSS) as a Date value.
+   *
+   * @param s the string to be parsed
+   * @return the resulting Date value
+   * @throws ParseException error during parsing
+   */
+  public static Date parseAsDateTime(String s) throws ParseException {
+    Date d;
+    synchronized (utcDateTimeFormatter) {
+      d = utcDateTimeFormatter.parse(s);
+    }
+    return d;
+  }
+}

--- a/src/main/java/com/ibm/cloud/sdk/core/util/OpenAPIDateSerializer.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/OpenAPIDateSerializer.java
@@ -1,0 +1,41 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.sdk.core.util;
+
+import java.lang.reflect.Type;
+import java.util.Date;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * This class will serialize a java.util.Date instance associated with an OpenAPI "date" schema property.
+ * The "deserialize" method is inherited from the DateDeserializer class.
+ */
+public class OpenAPIDateSerializer extends DateDeserializer implements JsonSerializer<Date> {
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see com.google.gson.JsonSerializer#serialize(java.lang.Object, java.lang.reflect.Type,
+   * com.google.gson.JsonSerializationContext)
+   */
+  @Override
+  public synchronized JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
+    return src == null ? JsonNull.INSTANCE : new JsonPrimitive(DateUtils.formatAsDate(src));
+  }
+}

--- a/src/main/java/com/ibm/cloud/sdk/core/util/OpenAPIDateTimeSerializer.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/OpenAPIDateTimeSerializer.java
@@ -1,0 +1,41 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.sdk.core.util;
+
+import java.lang.reflect.Type;
+import java.util.Date;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * This class will serialize a java.util.Date instance associated with an OpenAPI "date-time" schema property.
+ * The "deserialize" method is inherited from the DateDeserializer class.
+ */
+public class OpenAPIDateTimeSerializer extends DateDeserializer implements JsonSerializer<Date> {
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see com.google.gson.JsonSerializer#serialize(java.lang.Object, java.lang.reflect.Type,
+   * com.google.gson.JsonSerializationContext)
+   */
+  @Override
+  public synchronized JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
+    return src == null ? JsonNull.INSTANCE : new JsonPrimitive(DateUtils.formatAsDateTime(src));
+  }
+}

--- a/src/test/java/com/ibm/cloud/sdk/core/util/DateDeserializerTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/DateDeserializerTest.java
@@ -17,14 +17,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 import org.junit.Test;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-import com.ibm.cloud.sdk.core.util.DateDeserializer;
-
-import java.text.SimpleDateFormat;
-import java.util.Date;
 
 /**
  * Test the Date deserializer.

--- a/src/test/java/com/ibm/cloud/sdk/core/util/DateUtilsTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/DateUtilsTest.java
@@ -1,0 +1,104 @@
+/**
+ * (C) Copyright IBM Corp. 2015, 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.sdk.core.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.gson.JsonParseException;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Tests related to the DateUtils class.
+ */
+@SuppressWarnings("deprecation")
+public class DateUtilsTest {
+
+  private String serialize(Object obj) {
+    return GsonSingleton.getGson().toJson(obj);
+  }
+
+  private <T> T deserialize(String json, Class<T> clazz) {
+    return GsonSingleton.getGson().fromJson(json, clazz);
+  }
+
+  @Test
+  public void testDate() throws Exception {
+    Date expectedDate = new Date(120, 10, 03);
+    Date d = DateUtils.parseAsDate("2020-11-03");
+    assertNotNull(d);
+    assertEquals(expectedDate, d);
+
+    String s = DateUtils.formatAsDate(d);
+    assertNotNull(s);
+    assertEquals("2020-11-03", s);
+  }
+
+  @Test
+  public void testDateTime() throws Exception {
+    Date expectedDate = new Date(120, 10, 03, 19, 01, 33);
+    Date d = DateUtils.parseAsDateTime("2020-11-03T19:01:33.000");
+    assertNotNull(d);
+    assertEquals(expectedDate, d);
+
+    String s = DateUtils.formatAsDateTime(d);
+    assertNotNull(s);
+    assertEquals("2020-11-03T19:01:33.000", s);
+  }
+
+  // Simulates a generated model with "date" and "date-time" fields.
+  // This will exercise the OpenAPIDateSerializer and OpenAPIDateTimeSerializer classes.
+  public class MyModel extends GenericModel {
+    @JsonAdapter(OpenAPIDateSerializer.class)
+    @SerializedName("date_field")
+    public Date dateField;
+
+    @JsonAdapter(OpenAPIDateTimeSerializer.class)
+    @SerializedName("date_time_field")
+    public Date dateTimeField;
+  }
+
+  @Test
+  public void testModel() {
+    MyModel myModel = new MyModel();
+    myModel.dateField = new Date(120, 10, 03);
+    myModel.dateTimeField = new Date(120, 10, 03, 19, 01, 33);
+
+    String s = serialize(myModel);
+
+    MyModel newModel = deserialize(s, MyModel.class);
+    assertNotNull(newModel);
+    assertEquals(myModel, newModel);
+  }
+
+  @Test(expected = JsonParseException.class)
+  public void testModelErrorDate() {
+    String badJson = "{\"date_field\": \"bad-date\", \"date_time_field\": \"2020-11-03T19:01:33.000\"}";
+    deserialize(badJson, MyModel.class);
+  }
+
+  @Test(expected = JsonParseException.class)
+  public void testModelErrorDateTime() {
+    String badJson = "{\"date_field\": \"2020-11-03\", \"date_time_field\": \"bad-date-time\"}";
+    deserialize(badJson, MyModel.class);
+  }
+}


### PR DESCRIPTION
Fixes arf/planning-sdk-squad#2289

This commit introduces a new class (DateUtils) which will
be used by the Java generator to properly format date and date-time
values when they are used as query parameters.