### PR TITLE
feat(authentication): support cp4d /v1/authorize operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ config
 .secrets.baseline
 .vscode/
 package-lock.json
+*.env

--- a/Authentication.md
+++ b/Authentication.md
@@ -10,7 +10,7 @@ The SDK user configures the appropriate type of authentication for use with serv
 The authentication types that are appropriate for a particular service may vary from service to service, so it is important for the SDK user to consult with the appropriate service documentation to understand which authenticators are supported for that service.
 
 The java-sdk-core allows an authenticator to be specified in one of two ways:
-1. programmatically - the SDK user invokes the appropriate constructor to create an instance of the desired authenticator and then passes the authenticator instance when constructing an instance of the service.
+1. programmatically - the SDK user constructs an instance of the desired authenticator using the appropriate Builder class or constructor, and then passes the authenticator instance when constructing an instance of the service.
 2. configuration - the SDK user provides external configuration information (in the form of environment variables or a credentials file) to indicate the type of authenticator along with the configuration of the necessary properties for that authenticator.  The SDK user then invokes the configuration-based authenticator factory to construct an instance of the authenticator that is described in the external configuration information.
 
 The sections below will provide detailed information for each authenticator
@@ -38,7 +38,10 @@ import com.ibm.cloud.sdk.core.security.BasicAuthenticator;
 import <sdk_base_package>.ExampleService.v1.ExampleService;
 ...
 // Create the authenticator.
-BasicAuthenticator authenticator = new BasicAuthenticator("myuser", "mypassword");
+BasicAuthenticator authenticator = new BasicAuthenticator.Builder()
+    .username("myuser")
+    .password("mypassword")
+    .build();
 
 // Create the service instance.
 ExampleService service = new ExampleService(authenticator);
@@ -151,7 +154,9 @@ import com.ibm.cloud.sdk.core.security.IamAuthenticator;
 import <sdk_base_package>.ExampleService.v1.ExampleService;
 ...
 // Create the authenticator.
-IamAuthenticator authenticator = new IamAuthenticator("myapikey");
+IamAuthenticator authenticator = new IamAuthenticator.Builder()
+    .apikey("myapikey")
+    .build();
 
 // Create the service instance.
 ExampleService service = new ExampleService(authenticator);
@@ -179,7 +184,7 @@ ExampleService service = new ExampleService(authenticator);
 ```
 
 ##  Cloud Pak for Data
-The `CloudPakForDataAuthenticator` will accept user-supplied username and password values, and will 
+The `CloudPakForDataAuthenticator` will accept user-supplied values for the username and either a password or apikey, and will 
 perform the necessary interactions with the Cloud Pak for Data token service to obtain a suitable
 bearer token.  The authenticator will also obtain a new bearer token when the current token expires.
 The bearer token is then added to each outbound request in the `Authorization` header in the
@@ -189,8 +194,9 @@ form:
 ```
 ### Properties
 - username: (required) the username used to obtain a bearer token.
-- password: (required) the password used to obtain a bearer token.
-- url: (required) The URL representing the Cloud Pak for Data token service endpoint.
+- password: (required if apikey is not specified) the password used to obtain a bearer token.
+- apikey: (required if password is not specified) the apikey used to obtain a bearer token.
+- url: (required) The base URL associated with the Cloud Pak for Data token service.
 - disableSSLVerification: (optional) A flag that indicates whether verificaton of the server's SSL 
 certificate should be disabled or not. The default value is `false`.
 - headers: (optional) A set of key/value pairs that will be sent as HTTP headers in requests
@@ -201,7 +207,11 @@ import com.ibm.cloud.sdk.core.security.CloudPakForDataAuthenticator;
 import <sdk_base_package>.ExampleService.v1.ExampleService;
 ...
 // Create the authenticator.
-CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator("https://mycp4dhost.com/", "myuser", "mypassword");
+CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator.Builder()
+    .url("https://mycp4dhost.com/")
+    .username("myuser")
+    .password("mypassword")
+    .build();
 
 // Create the service instance.
 ExampleService service = new ExampleService(authenticator);

--- a/src/main/java/com/ibm/cloud/sdk/core/security/AuthenticatorBase.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/AuthenticatorBase.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019.
+ * (C) Copyright IBM Corp. 2019, 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -29,6 +29,7 @@ public class AuthenticatorBase {
   public static final String ERRORMSG_PROP_INVALID =
       "The %s property is invalid. Please remove any surrounding {, }, or \" characters.";
   public static final String ERRORMSG_REQ_FAILED = "Error while fetching access token from token service: ";
+  public static final String ERRORMSG_EXCLUSIVE_PROP_ERROR = "Exactly one of %s or %s must be specified.";
 
   /**
    * Returns a "Basic" Authorization header value for the specified username and password.

--- a/src/main/java/com/ibm/cloud/sdk/core/security/BearerTokenAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/BearerTokenAuthenticator.java
@@ -49,10 +49,25 @@ public class BearerTokenAuthenticator extends AuthenticatorBase implements Authe
 
   /**
    * Construct a BearerTokenAuthenticator using properties retrieved from the specified Map.
+   *
    * @param config a map containing the access token value
+   *
+   * @deprecated As of 9.7.0, use BearerTokenAuthenticator.fromConfiguration() instead.
    */
   public BearerTokenAuthenticator(Map<String, String> config) {
     setBearerToken(config.get(PROPNAME_BEARER_TOKEN));
+  }
+
+  /**
+   * Construct a BearerTokenAuthenticator instance using properties retrieved from the specified Map.
+   *
+   * @param config a map containing the configuration properties
+   *
+   * @return the BearerTokenAuthenticator instance
+   *
+   */
+  public static BearerTokenAuthenticator fromConfiguration(Map<String, String> config) {
+    return new BearerTokenAuthenticator(config.get(PROPNAME_BEARER_TOKEN));
   }
 
   @Override

--- a/src/main/java/com/ibm/cloud/sdk/core/security/CloudPakForDataAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/CloudPakForDataAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019.
+ * (C) Copyright IBM Corp. 2019, 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,50 +13,213 @@
 
 package com.ibm.cloud.sdk.core.security;
 
+import java.io.InputStream;
+import java.net.Proxy;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.http.HttpHeaders;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
 
 /**
  * This class provides an Authenticator implementation for the "CloudPakForData" environment.
- * This authenticator will use the configured url, username and password values to automatically fetch
- * an access token from the Token Server.
+ * This authenticator will use the configured url and other properties to automatically fetch
+ * an access token from the CloudPakForData token service.
  * When the access token expires, a new access token will be fetched.
+ *
+ * This authenticator uses the "POST /v1/authorize" operation supported by the CloudPakForData token service.
+ * As such, you can configure either the username and passord properies, or the username and apikey
+ * properties.  The url, username and one of password/apikey are required.
  */
 public class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator<Cp4dToken, Cp4dTokenResponse>
   implements Authenticator {
 
-  // This is the suffix we'll need to add to the user-supplied URL to retrieve an access token.
-  private static final String URL_SUFFIX = "/v1/preauth/validateAuth";
-
+  // Properties specific to a CloudPakForData authenticator.
   private String url;
+  private String username;
+  private String password;
+  private String apikey;
+
+  /**
+   * This Builder class is used to construct CloudPakForDataAuthenticator instances.
+   */
+  public static class Builder {
+    private String url;
+    private String username;
+    private String password;
+    private String apikey;
+    private boolean disableSSLVerification;
+    private Map<String, String> headers;
+    private Proxy proxy;
+    private okhttp3.Authenticator proxyAuthenticator;
+
+    // Default ctor.
+    public Builder() { }
+
+    // Builder ctor which copies config from an existing authenticator instance.
+    private Builder(CloudPakForDataAuthenticator obj) {
+      this.url = obj.url;
+      this.username = obj.username;
+      this.password = obj.password;
+      this.apikey = obj.apikey;
+
+      this.disableSSLVerification = obj.getDisableSSLVerification();
+      this.headers = obj.getHeaders();
+      this.proxy = obj.getProxy();
+      this.proxyAuthenticator = obj.getProxyAuthenticator();
+    }
+
+    /**
+     * Constructs a new instance of CloudPakForDataAuthenticator from the builder's configuration.
+     *
+     * @return the CloudPakForDataAuthenticator instance
+     */
+    public CloudPakForDataAuthenticator build() {
+      return new CloudPakForDataAuthenticator(this);
+    }
+
+    /**
+     * Sets the url property.
+     * @param url the base url to use with the CloudPakForData token service
+     * @return the Builder
+     */
+    public Builder url(String url) {
+      this.url = url;
+      return this;
+    }
+
+    /**
+     * Sets the username property.
+     * @param username the username to use when retrieving an access token
+     * @return the Builder
+     */
+    public Builder username(String username) {
+      this.username = username;
+      return this;
+    }
+
+    /**
+     * Sets the password property.
+     * @param password the password to use when retrieving an access token
+     * @return the Builder
+     */
+    public Builder password(String password) {
+      this.password = password;
+      return this;
+    }
+
+    /**
+     * Sets the apikey property.
+     * @param apikey the apikey to use when retrieving an access token
+     * @return the Builder
+     */
+    public Builder apikey(String apikey) {
+      this.apikey = apikey;
+      return this;
+    }
+
+    /**
+     * Sets the disableSSLVerification property.
+     * @param disableSSLVerification a boolean flag indicating whether or not SSL verification should be disabled
+     * when interacting with the CloudPakForData token service
+     * @return the Builder
+     */
+    public Builder disableSSLVerification(boolean disableSSLVerification) {
+      this.disableSSLVerification = disableSSLVerification;
+      return this;
+    }
+
+    /**
+     * Sets the headers property.
+     * @param headers the set of custom headers to include in requests sent to the CloudPakForData token service
+     * @return the Builder
+     */
+    public Builder headers(Map<String, String> headers) {
+      this.headers = headers;
+      return this;
+    }
+
+    /**
+     * Sets the proxy property.
+     * @param proxy the java.net.Proxy instance to be used when interacting with the CloudPakForData token service
+     * @return the Builder
+     */
+    public Builder proxy(Proxy proxy) {
+      this.proxy = proxy;
+      return this;
+    }
+
+    /**
+     * Sets the proxyAuthenticator property.
+     * @param proxyAuthenticator the okhttp3.Authenticator instance to be used with the proxy when
+     * interacting with the CloudPakForData token service
+     * @return the Builder
+     */
+    public Builder proxyAuthenticator(okhttp3.Authenticator proxyAuthenticator) {
+      this.proxyAuthenticator = proxyAuthenticator;
+      return this;
+    }
+  }
 
   // The default ctor is hidden to force the use of the non-default ctors.
   protected CloudPakForDataAuthenticator() {
   }
 
   /**
-   * Constructs a CloudPakForDataAuthenticator with required properties.
+   * Constructs a CloudPakForDataAuthenticator instance from the configuration
+   * contained in "builder".
+   *
+   * @param builder the Builder instance containing the configuration to be used
+   */
+  protected CloudPakForDataAuthenticator(Builder builder) {
+    this.url = builder.url;
+    this.username = builder.username;
+    this.password = builder.password;
+    this.apikey = builder.apikey;
+
+    setDisableSSLVerification(builder.disableSSLVerification);
+    setHeaders(builder.headers);
+    setProxy(builder.proxy);
+    setProxyAuthenticator(builder.proxyAuthenticator);
+
+    this.validate();
+  }
+
+  /**
+   * Returns a new Builder instance pre-loaded with the configuration from "this".
+   *
+   * @return the builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Constructs a CloudPakForDataAuthenticator with required properties configured with username/password.
    *
    * @param url
-   *          the base URL associated with the token server. The path "/v1/preauth/validateAuth" will be appended to
+   *          the base URL associated with the token service. The path "/v1/authorize" will be appended to
    *          this value automatically.
    * @param username
    *          the username to be used when retrieving the access token
    * @param password
    *          the password to be used when retrieving the access token
+   *
+   * @deprecated As of 9.7.0, use CloudPakForDataAuthenticator.Builder() instead.
+   *
    */
+  @Deprecated
   public CloudPakForDataAuthenticator(String url, String username, String password) {
     init(url, username, password, false, null);
   }
 
   /**
-   * Constructs a CloudPakForDataAuthenticator with all properties.
+   * Constructs a CloudPakForDataAuthenticator with all properties configured with username/password.
    *
    * @param url
-   *          the base URL associated with the token server. The path "/v1/preauth/validateAuth" will be appended to
+   *          the base URL associated with the token service. The path "/v1/authorize" will be appended to
    *          this value automatically.
    * @param username
    *          the username to be used when retrieving the access token
@@ -65,8 +228,12 @@ public class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
    * @param disableSSLVerification
    *          a flag indicating whether SSL hostname verification should be disabled
    * @param headers
-   *          a set of user-supplied headers to be included in token server interactions
+   *          a set of user-supplied headers to be included in token service interactions
+   *
+   * @deprecated As of 9.7.0, use CloudPakForDataAuthenticator.Builder() instead.
+   *
    */
+  @Deprecated
   public CloudPakForDataAuthenticator(String url, String username, String password,
     boolean disableSSLVerification, Map<String, String> headers) {
     init(url, username, password, disableSSLVerification, headers);
@@ -74,17 +241,41 @@ public class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
 
   /**
    * Construct a CloudPakForDataAuthenticator instance using properties retrieved from the specified Map.
+   *
    * @param config a map containing the configuration properties
+   *
+   * @deprecated As of 9.7.0, use CloudPakForDataAuthenticator.fromConfiguration() instead.
+   *
    */
+  @Deprecated
   public CloudPakForDataAuthenticator(Map<String, String> config) {
+    this.apikey = config.get(PROPNAME_APIKEY);
     init(config.get(PROPNAME_URL), config.get(PROPNAME_USERNAME),
       config.get(PROPNAME_PASSWORD), Boolean.valueOf(config.get(PROPNAME_DISABLE_SSL)).booleanValue(), null);
   }
 
   /**
+   * Construct a CloudPakForDataAuthenticator instance using properties retrieved from the specified Map.
+   *
+   * @param config a map containing the configuration properties
+   *
+   * @return the CloudPakForDataAuthenticator instance
+   *
+   */
+  public static CloudPakForDataAuthenticator fromConfiguration(Map<String, String> config) {
+    return new Builder()
+      .url(config.get(PROPNAME_URL))
+      .username(config.get(PROPNAME_USERNAME))
+      .password(config.get(PROPNAME_PASSWORD))
+      .apikey(config.get(PROPNAME_APIKEY))
+      .disableSSLVerification(Boolean.valueOf(config.get(PROPNAME_DISABLE_SSL)).booleanValue())
+      .build();
+  }
+
+  /**
    * Initializes the authenticator with all the specified properties.
    * @param url
-   *          the base URL associated with the token server. The path "/v1/preauth/validateAuth" will be appended to
+   *          the base URL associated with the token service. The path "/v1/preauth/validateAuth" will be appended to
    *          this value automatically.
    * @param username
    *          the username to be used when retrieving the access token
@@ -93,14 +284,17 @@ public class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
    * @param disableSSLVerification
    *          a flag indicating whether SSL hostname verification should be disabled
    * @param headers
-   *          a set of user-supplied headers to be included in token server interactions
+   *          a set of user-supplied headers to be included in token service interactions
    */
   protected void init(String url, String username, String password,
     boolean disableSSLVerification, Map<String, String> headers) {
     this.url = url;
-    setBasicAuthInfo(username, password);
+    this.username = username;
+    this.password = password;
+
     setDisableSSLVerification(disableSSLVerification);
     setHeaders(headers);
+
     this.validate();
   }
 
@@ -118,45 +312,67 @@ public class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
    */
   @Override
   public void validate() {
-    if (StringUtils.isEmpty(url)) {
+    if (StringUtils.isEmpty(this.url)) {
       throw new IllegalArgumentException(String.format(ERRORMSG_PROP_MISSING, "url"));
     }
 
-    if (StringUtils.isEmpty(getUsername())) {
+    if (StringUtils.isEmpty(this.username)) {
       throw new IllegalArgumentException(String.format(ERRORMSG_PROP_MISSING, "username"));
     }
 
-    if (StringUtils.isEmpty(getPassword())) {
-      throw new IllegalArgumentException(String.format(ERRORMSG_PROP_MISSING, "password"));
+    // Either password or apikey need to be specified, but not both.
+    if ((StringUtils.isEmpty(this.password) && StringUtils.isEmpty(this.apikey))
+        || (StringUtils.isNotEmpty(this.password) && StringUtils.isNotEmpty(this.apikey))) {
+      throw new IllegalArgumentException(String.format(ERRORMSG_EXCLUSIVE_PROP_ERROR, "password", "apikey"));
     }
   }
 
   /**
-   * @return the URL configured for this authenticator.
+   * @return the URL configured for this authenticator
    */
   public String getURL() {
     return this.url;
   }
 
   /**
-   * Obtains a CP4D access token for the username/password combination using the configured URL.
+   * @return the username configured for this authenticator
+   */
+  public String getUsername() {
+    return this.username;
+  }
+
+  /**
+   * @return the password configured for this authenticator
+   */
+  public String getPassword() {
+    return this.password;
+  }
+
+  /**
+   * @return the apikey configured for this authenticator
+   */
+  public String getApikey() {
+    return this.apikey;
+  }
+
+  /**
+   * Obtains a CP4D access token for the configured authenticator.
    *
    * @return a Cp4dToken instance that contains the access token
    */
   @Override
   public Cp4dToken requestToken() {
-    // Form a GET request to retrieve the access token.
+    // Form a POST request to retrieve the access token.
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(this.url, "/v1/authorize"));
 
-    // If the user did not include the path on the URL property, then add it now.
-    String requestUrl = this.url;
-    if (!requestUrl.endsWith(URL_SUFFIX)) {
-      requestUrl += URL_SUFFIX;
-    }
-    requestUrl = requestUrl.replace("//", "/");
+    // Add the Content-Type header.
+    builder.header(HttpHeaders.CONTENT_TYPE, "application/json");
 
-    RequestBuilder builder = RequestBuilder.get(RequestBuilder.constructHttpUrl(requestUrl, new String[0]));
+    // Add the request body.
+    CP4DRequestBody requestBody = new CP4DRequestBody(this.username, this.password, this.apikey);
+    builder.bodyContent("application/json", requestBody, null, (InputStream) null);
 
-    // Invoke the GET request.
+    // Invoke the POST request.
     Cp4dToken token;
     try {
       Cp4dTokenResponse response = invokeRequest(builder, Cp4dTokenResponse.class);
@@ -167,5 +383,23 @@ public class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
 
     // Construct a new Cp4dToken object from the response and return it.
     return token;
+  }
+
+  // This class models the "POST /v1/authorize" request body.
+  // Only one of "password" or "apikey" will be non-null so we can use this
+  // class for both scenarios (username/password and username/apikey).
+  @SuppressWarnings("unused")
+  private static class CP4DRequestBody {
+    private String username;
+    private String password;
+
+    @SerializedName("api_key")
+    private String apikey;
+
+    CP4DRequestBody(String username, String password, String apikey) {
+      this.username = username;
+      this.password = password;
+      this.apikey = apikey;
+    }
   }
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/security/ConfigBasedAuthenticatorFactory.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/ConfigBasedAuthenticatorFactory.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019.
+ * (C) Copyright IBM Corp. 2019, 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -69,13 +69,13 @@ public class ConfigBasedAuthenticatorFactory {
 
     // Create the appropriate authenticator based on the auth type.
     if (authType.equalsIgnoreCase(Authenticator.AUTHTYPE_BASIC)) {
-      authenticator = new BasicAuthenticator(props);
+      authenticator = BasicAuthenticator.fromConfiguration(props);
     } else if (authType.equalsIgnoreCase(Authenticator.AUTHTYPE_BEARER_TOKEN)) {
-      authenticator = new BearerTokenAuthenticator(props);
+      authenticator = BearerTokenAuthenticator.fromConfiguration(props);
     } else if (authType.equalsIgnoreCase(Authenticator.AUTHTYPE_CP4D)) {
-      authenticator = new CloudPakForDataAuthenticator(props);
+      authenticator = CloudPakForDataAuthenticator.fromConfiguration(props);
     } else if (authType.equalsIgnoreCase(Authenticator.AUTHTYPE_IAM)) {
-      authenticator = new IamAuthenticator(props);
+      authenticator = IamAuthenticator.fromConfiguration(props);
     } else if (authType.equalsIgnoreCase(Authenticator.AUTHTYPE_NOAUTH)) {
       authenticator = new NoAuthAuthenticator(props);
     } else {

--- a/src/main/java/com/ibm/cloud/sdk/core/security/Cp4dToken.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/Cp4dToken.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019.
+ * (C) Copyright IBM Corp. 2019, 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -56,7 +56,7 @@ public class Cp4dToken extends AbstractToken {
    */
   public Cp4dToken(Cp4dTokenResponse response) {
     super();
-    this.accessToken = response.getAccessToken();
+    this.accessToken = response.getToken();
 
     // To compute the expiration time, we'll need to crack open the accessToken value
     // which is a JWToken (Json Web Token) instance.

--- a/src/main/java/com/ibm/cloud/sdk/core/security/Cp4dTokenResponse.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/Cp4dTokenResponse.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019.
+ * (C) Copyright IBM Corp. 2019, 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,68 +14,19 @@
 package com.ibm.cloud.sdk.core.security;
 
 /**
- * This class models a response received from the CP4D "get token" API.
+ * This class models a response received from the CP4D "POST /v1/authorize" operation.
  */
 public class Cp4dTokenResponse implements TokenServerResponse {
 
-  private String username;
-  private String role;
-  private String[] permissions;
-  private String sub;
-  private String iss;
-  private String aud;
-  private String uid;
-  private String accessToken;
+  private String token;
   private String _messageCode_;
   private String message;
 
-  public String getUsername() {
-    return username;
+  public String getToken() {
+    return token;
   }
-  public void setUsername(String username) {
-    this.username = username;
-  }
-  public String getRole() {
-    return role;
-  }
-  public void setRole(String role) {
-    this.role = role;
-  }
-  public String[] getPermissions() {
-    return permissions;
-  }
-  public void setPermissions(String[] permissions) {
-    this.permissions = permissions;
-  }
-  public String getSub() {
-    return sub;
-  }
-  public void setSub(String sub) {
-    this.sub = sub;
-  }
-  public String getIss() {
-    return iss;
-  }
-  public void setIss(String iss) {
-    this.iss = iss;
-  }
-  public String getAud() {
-    return aud;
-  }
-  public void setAud(String aud) {
-    this.aud = aud;
-  }
-  public String getUid() {
-    return uid;
-  }
-  public void setUid(String uid) {
-    this.uid = uid;
-  }
-  public String getAccessToken() {
-    return accessToken;
-  }
-  public void setAccessToken(String accessToken) {
-    this.accessToken = accessToken;
+  public void setToken(String token) {
+    this.token = token;
   }
   public String get_messageCode_() {
     return _messageCode_;

--- a/src/main/java/com/ibm/cloud/sdk/core/security/IamAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/IamAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2015, 2019.
+ * (C) Copyright IBM Corp. 2015, 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.sdk.core.security;
 
+import java.net.Proxy;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -27,15 +28,12 @@ import okhttp3.FormBody;
 /**
  * This class provides an Authenticator implementation for IAM (Identity and Access Management).
  * This authenticator will use the url and apikey values to automatically fetch
- * an access token from the Token Server.
+ * an access token from the IAM token service via the "POST /identity/token" operation.
  * When the access token expires, a new access token will be fetched.
  */
 public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, IamToken> implements Authenticator {
-  private String apikey;
-  private String url;
-  private String scope;
-
-  private static final String DEFAULT_IAM_URL = "https://iam.cloud.ibm.com/identity/token";
+  private static final String DEFAULT_IAM_URL = "https://iam.cloud.ibm.com";
+  private static final String OPERATION_PATH = "/identity/token";
   private static final String GRANT_TYPE = "grant_type";
   private static final String REQUEST_GRANT_TYPE = "urn:ibm:params:oauth:grant-type:apikey";
   private static final String API_KEY = "apikey";
@@ -43,8 +41,181 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
   private static final String CLOUD_IAM = "cloud_iam";
   private static final String SCOPE = "scope";
 
+  // Properties specific to an IAM authenticator.
+  private String url;
+  private String apikey;
+  private String scope;
+  private String clientId;
+  private String clientSecret;
+
+  // This is the value of the Authorization header we'll use when interacting with the token server.
+  private String cachedAuthorizationHeader = null;
+
+  /**
+   * This Builder class is used to construct IamAuthenticator instances.
+   */
+  public static class Builder {
+    private String url;
+    private String apikey;
+    private String scope;
+    private String clientId;
+    private String clientSecret;
+    private boolean disableSSLVerification;
+    private Map<String, String> headers;
+    private Proxy proxy;
+    private okhttp3.Authenticator proxyAuthenticator;
+
+    // Default ctor.
+    public Builder() { }
+
+    // Builder ctor which copies config from an existing authenticator instance.
+    private Builder(IamAuthenticator obj) {
+      this.url = obj.url;
+      this.apikey = obj.apikey;
+      this.scope = obj.scope;
+      this.clientId = obj.clientId;
+      this.clientSecret = obj.clientSecret;
+
+      this.disableSSLVerification = obj.getDisableSSLVerification();
+      this.headers = obj.getHeaders();
+      this.proxy = obj.getProxy();
+      this.proxyAuthenticator = obj.getProxyAuthenticator();
+    }
+
+    /**
+     * Constructs a new instance of IamAuthenticator from the builder's configuration.
+     *
+     * @return the IamAuthenticator instance
+     */
+    public IamAuthenticator build() {
+      return new IamAuthenticator(this);
+    }
+
+    /**
+     * Sets the url property.
+     * @param url the base url to use with the IAM token service
+     * @return the Builder
+     */
+    public Builder url(String url) {
+      this.url = url;
+      return this;
+    }
+
+    /**
+     * Sets the clientId property.
+     * @param clientId the clientId to use when retrieving an access token
+     * @return the Builder
+     */
+    public Builder clientId(String clientId) {
+      this.clientId = clientId;
+      return this;
+    }
+
+    /**
+     * Sets the clientSecret property.
+     * @param clientSecret the clientSecret to use when retrieving an access token
+     * @return the Builder
+     */
+    public Builder clientSecret(String clientSecret) {
+      this.clientSecret = clientSecret;
+      return this;
+    }
+
+    /**
+     * Sets the apikey property.
+     * @param apikey the apikey to use when retrieving an access token
+     * @return the Builder
+     */
+    public Builder apikey(String apikey) {
+      this.apikey = apikey;
+      return this;
+    }
+
+    /**
+     * Sets the scope property.
+     * @param scope the scope to use when retrieving an access token
+     * @return the Builder
+     */
+    public Builder scope(String scope) {
+      this.scope = scope;
+      return this;
+    }
+
+    /**
+     * Sets the disableSSLVerification property.
+     * @param disableSSLVerification a boolean flag indicating whether or not SSL verification should be disabled
+     * when interacting with the IAM token service
+     * @return the Builder
+     */
+    public Builder disableSSLVerification(boolean disableSSLVerification) {
+      this.disableSSLVerification = disableSSLVerification;
+      return this;
+    }
+
+    /**
+     * Sets the headers property.
+     * @param headers the set of custom headers to include in requests sent to the IAM token service
+     * @return the Builder
+     */
+    public Builder headers(Map<String, String> headers) {
+      this.headers = headers;
+      return this;
+    }
+
+    /**
+     * Sets the proxy property.
+     * @param proxy the java.net.Proxy instance to be used when interacting with the IAM token server
+     * @return the Builder
+     */
+    public Builder proxy(Proxy proxy) {
+      this.proxy = proxy;
+      return this;
+    }
+
+    /**
+     * Sets the proxyAuthenticator property.
+     * @param proxyAuthenticator the okhttp3.Authenticator instance to be used with the proxy when
+     * interacting with the IAM token service
+     * @return the Builder
+     */
+    public Builder proxyAuthenticator(okhttp3.Authenticator proxyAuthenticator) {
+      this.proxyAuthenticator = proxyAuthenticator;
+      return this;
+    }
+  }
+
   // The default ctor is hidden to force the use of the non-default ctors.
   protected IamAuthenticator() {
+  }
+
+  /**
+   * Constructs an IamAuthenticator instance from the configuration
+   * contained in "builder".
+   *
+   * @param builder the Builder instance containing the configuration to be used
+   */
+  protected IamAuthenticator(Builder builder) {
+    this.url = builder.url;
+    this.apikey = builder.apikey;
+    this.scope = builder.scope;
+    this.clientId = builder.clientId;
+    this.clientSecret = builder.clientSecret;
+
+    setDisableSSLVerification(builder.disableSSLVerification);
+    setHeaders(builder.headers);
+    setProxy(builder.proxy);
+    setProxyAuthenticator(builder.proxyAuthenticator);
+
+    this.validate();
+  }
+
+  /**
+   * Returns a new Builder instance pre-loaded with the configuration from "this".
+   *
+   * @return the Builder instance
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
   }
 
   /**
@@ -52,7 +223,11 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
    *
    * @param apikey
    *          the apikey to be used when retrieving the access token
+   *
+   * @deprecated As of 9.7.0, use IamAuthenticator.Builder() instead
+   *
    */
+  @Deprecated
   public IamAuthenticator(String apikey) {
     init(apikey, null, null, null, false, null, null);
   }
@@ -63,7 +238,7 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
    * @param apikey
    *          the apikey to be used when retrieving the access token
    * @param url
-   *          the URL representing the token server endpoint
+   *          the base URL of the IAM token service (if null/empty, then "https://iam.cloud.ibm.com" is used)
    * @param clientId
    *          the clientId to be used in token server interactions
    * @param clientSecret
@@ -72,7 +247,11 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
    *          a flag indicating whether SSL hostname verification should be disabled
    * @param headers
    *          a set of user-supplied headers to be included in token server interactions
+   *
+   * @deprecated As of 9.7.0, use IamAuthenticator.Builder() instead
+   *
    */
+  @Deprecated
   public IamAuthenticator(String apikey, String url, String clientId, String clientSecret,
     boolean disableSSLVerification, Map<String, String> headers) {
     init(apikey, url, clientId, clientSecret, disableSSLVerification, headers, null);
@@ -84,7 +263,7 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
    * @param apikey
    *          the apikey to be used when retrieving the access token
    * @param url
-   *          the URL representing the token server endpoint
+   *          the base URL of the IAM token service (if null/empty, then "https://iam.cloud.ibm.com" is used)
    * @param clientId
    *          the clientId to be used in token server interactions
    * @param clientSecret
@@ -96,7 +275,11 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
    * @param scope
    *          the "scope" to use when fetching the bearer token from the IAM token server.
    *          This can be used to obtain an access token with a specific scope.
+   *
+   * @deprecated As of 9.7.0, use IamAuthenticator.Builder() instead
+   *
    */
+  @Deprecated
   public IamAuthenticator(String apikey, String url, String clientId, String clientSecret,
     boolean disableSSLVerification, Map<String, String> headers, String scope) {
     init(apikey, url, clientId, clientSecret, disableSSLVerification, headers, scope);
@@ -104,8 +287,13 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
 
   /**
    * Construct an IamAuthenticator instance using properties retrieved from the specified Map.
+   *
    * @param config a map containing the configuration properties
+   *
+   * @deprecated As of 9.7.0, use IamAuthenticator.Builder() instead
+   *
    */
+  @Deprecated
   public IamAuthenticator(Map<String, String> config) {
     String apikey = config.get(PROPNAME_APIKEY);
     if (StringUtils.isEmpty(apikey)) {
@@ -117,12 +305,36 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
   }
 
   /**
+   * Construct a IamAuthenticator instance using properties retrieved from the specified Map.
+   *
+   * @param config a map containing the configuration properties
+   *
+   * @return the IamAuthenticator instance
+   */
+  public static IamAuthenticator fromConfiguration(Map<String, String> config) {
+    // We support both APIKEY and IAM_APIKEY properties for specifying the apikey value.
+    String apikey = config.get(PROPNAME_APIKEY);
+    if (StringUtils.isEmpty(apikey)) {
+      apikey = config.get("IAM_APIKEY");
+    }
+
+    return new Builder()
+      .url(config.get(PROPNAME_URL))
+      .apikey(apikey)
+      .scope(config.get(PROPNAME_SCOPE))
+      .clientId(config.get(PROPNAME_CLIENT_ID))
+      .clientSecret(config.get(PROPNAME_CLIENT_SECRET))
+      .disableSSLVerification(Boolean.valueOf(config.get(PROPNAME_DISABLE_SSL)).booleanValue())
+      .build();
+  }
+
+  /**
    * Initializes the authenticator with all the specified properties.
    *
    * @param apikey
    *          the apikey to be used when retrieving the access token
    * @param url
-   *          the URL representing the token server endpoint
+   *          the base URL of the IAM token service (if null/empty, then "https://iam.cloud.ibm.com" is used)
    * @param clientId
    *          the clientId to be used in token server interactions
    * @param clientSecret
@@ -138,18 +350,26 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
   protected void init(String apikey, String url, String clientId, String clientSecret,
     boolean disableSSLVerification, Map<String, String> headers, String scope) {
     this.apikey = apikey;
-    if (StringUtils.isEmpty(url)) {
-      url = DEFAULT_IAM_URL;
-    }
     this.url = url;
-    setDisableSSLVerification(disableSSLVerification);
-    setHeaders(headers);
     setClientIdAndSecret(clientId, clientSecret);
     setScope(scope);
+    this.validate();
+
+    setDisableSSLVerification(disableSSLVerification);
+    setHeaders(headers);
   }
 
   @Override
   public void validate() {
+
+    if (StringUtils.isEmpty(this.url)) {
+      // If no base URL was configured, then use the default IAM base URL.
+      this.url = DEFAULT_IAM_URL;
+    } else if (this.url.endsWith(OPERATION_PATH)) {
+      // Canonicalize the URL by removing the operation path from it if present.
+      this.url = this.url.substring(0, this.url.length() - OPERATION_PATH.length());
+    }
+
     if (StringUtils.isEmpty(this.apikey)) {
       throw new IllegalArgumentException(String.format(ERRORMSG_PROP_MISSING, "apikey"));
     }
@@ -168,6 +388,10 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
         throw new IllegalArgumentException(String.format(ERRORMSG_PROP_MISSING, "clientSecret"));
       }
     }
+
+    // Assuming everything validates clean, let's cache the basic auth header if
+    // the clientId/clientSecret properties are configured.
+    this.cachedAuthorizationHeader = constructBasicAuthHeader(this.clientId, this.clientSecret);
   }
 
   @Override
@@ -204,14 +428,46 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
    * @return the clientId configured on this Authenticator.
    */
   public String getClientId() {
-    return getUsername();
+    return this.clientId;
   }
 
   /**
    * @return the clientSecret configured on this Authenticator.
    */
   public String getClientSecret() {
-    return getPassword();
+    return this.clientSecret;
+  }
+
+  /**
+   * @return the basic auth username (clientId) configured for this Authenticator.
+   *
+   * @deprecated As of 9.7.0, use getClientId() instead
+   */
+  public String getUsername() {
+    return getClientId();
+  }
+
+  /**
+   * @return the basic auth password (clientSecret) configured for this Authenticator.
+   *
+   * @deprecated As of 9.7.0, use getClientSecret() instead
+   */
+  public String getPassword() {
+    return getClientSecret();
+  }
+
+  /**
+   * Sets the basic auth username and password values in this Authenticator.
+   * These values will be used to build a basic auth Authorization header that will be sent with
+   * each request to the token service.
+   * @param clientId the basic auth username
+   * @param clientSecret the basic auth password
+   *
+   * @deprecated As of 9.7.0, use IamAuthenticator.setClientIdAndSecret() instead
+   */
+  @Deprecated
+  public void setBasicAuthInfo(String clientId, String clientSecret) {
+    setClientIdAndSecret(clientId, clientSecret);
   }
 
   /**
@@ -220,7 +476,8 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
    * @param clientSecret the clientSecret to use in interactions with the token server
    */
   public void setClientIdAndSecret(String clientId, String clientSecret) {
-    setBasicAuthInfo(clientId, clientSecret);
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
     this.validate();
   }
 
@@ -246,11 +503,16 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
    */
   @Override
   public IamToken requestToken() {
-    RequestBuilder builder = RequestBuilder.post(RequestBuilder.constructHttpUrl(url, new String[0]));
+    // Form a POST request to retrieve the access token.
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(this.url, OPERATION_PATH));
 
     // Now add the Content-Type and (optionally) the Authorization header to the token server request.
     builder.header(HttpHeaders.CONTENT_TYPE, HttpMediaType.APPLICATION_FORM_URLENCODED);
+    if (StringUtils.isNotEmpty(this.cachedAuthorizationHeader)) {
+      builder.header(HttpHeaders.AUTHORIZATION, this.cachedAuthorizationHeader);
+    }
 
+    // Build the form request body.
     FormBody formBody;
     final FormBody.Builder formBodyBuilder = new FormBody.Builder()
         .add(GRANT_TYPE, REQUEST_GRANT_TYPE)
@@ -263,6 +525,7 @@ public class IamAuthenticator extends TokenRequestBasedAuthenticator<IamToken, I
     formBody = formBodyBuilder.build();
     builder.body(formBody);
 
+    // Invoke the POST request.
     IamToken token;
     try {
       token = invokeRequest(builder, IamToken.class);

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/BasicAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/BasicAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2015, 2019.
+ * (C) Copyright IBM Corp. 2015, 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.HashMap;
 import java.util.Map;
 
+@SuppressWarnings("deprecation")
 public class BasicAuthenticatorTest {
 
   @Test
@@ -48,20 +49,139 @@ public class BasicAuthenticatorTest {
     assertEquals("Basic " + BaseEncoding.base64().encode((username + ":" + password).getBytes()), authHeader);
   }
 
+
+  //
+  // Tests involving the Builder class and fromConfiguration() method.deprecated ctors.
+  //
+
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMissingUsername() {
+    new BasicAuthenticator.Builder()
+    .username(null)
+    .password("good-password")
+    .build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testEmptyUsername() {
+    new BasicAuthenticator.Builder()
+    .username("")
+    .password("good-password")
+    .build();
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidUsername() {
+    new BasicAuthenticator.Builder()
+    .username("{bad-username}")
+    .password("good-password")
+    .build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMissingPassword() {
+    new BasicAuthenticator.Builder()
+    .username("good-username")
+    .password(null)
+    .build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testEmptyPassword() {
+    new BasicAuthenticator.Builder()
+    .username("good-username")
+    .password("")
+    .build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidPassword() {
+    new BasicAuthenticator.Builder()
+    .username("good-username")
+    .password("{bad-password}")
+    .build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConfigMissingUsername() {
+    Map<String, String> props = new HashMap<>();
+    props.put(Authenticator.PROPNAME_USERNAME, null);
+    props.put(Authenticator.PROPNAME_PASSWORD, "good-password");
+    BasicAuthenticator.fromConfiguration(props);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConfigEmptyUsername() {
+    Map<String, String> props = new HashMap<>();
+    props.put(Authenticator.PROPNAME_USERNAME, "");
+    props.put(Authenticator.PROPNAME_PASSWORD, "good-password");
+    BasicAuthenticator.fromConfiguration(props);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConfigInvalidUsername() {
+    Map<String, String> props = new HashMap<>();
+    props.put(Authenticator.PROPNAME_USERNAME, "{bad-username}");
+    props.put(Authenticator.PROPNAME_PASSWORD, "good-password");
+    BasicAuthenticator.fromConfiguration(props);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConfigMissingPassword() {
+    Map<String, String> props = new HashMap<>();
+    props.put(Authenticator.PROPNAME_USERNAME, "good-username");
+    props.put(Authenticator.PROPNAME_PASSWORD, null);
+    BasicAuthenticator.fromConfiguration(props);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConfigEmptyPassword() {
+    Map<String, String> props = new HashMap<>();
+    props.put(Authenticator.PROPNAME_USERNAME, "good-username");
+    props.put(Authenticator.PROPNAME_PASSWORD, "");
+    BasicAuthenticator.fromConfiguration(props);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConfigInvalidPassword() {
+    Map<String, String> props = new HashMap<>();
+    props.put(Authenticator.PROPNAME_USERNAME, "good-username");
+    props.put(Authenticator.PROPNAME_PASSWORD, "{bad-password}");
+    BasicAuthenticator.fromConfiguration(props);
+  }
+
+  @Test
+  public void testConfigGoodConfig() {
+    Map<String, String> props = new HashMap<>();
+    props.put(Authenticator.PROPNAME_USERNAME, "good-username");
+    props.put(Authenticator.PROPNAME_PASSWORD, "good-password");
+    BasicAuthenticator authenticator = BasicAuthenticator.fromConfiguration(props);
+    assertNotNull(authenticator);
+    assertEquals(Authenticator.AUTHTYPE_BASIC, authenticator.authenticationType());
+    assertEquals("good-username", authenticator.getUsername());
+    assertEquals("good-password", authenticator.getPassword());
+  }
+
+
+  //
+  // Tests involving the deprecated ctors.
+  //
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCtorInvalidUsername() {
     new BasicAuthenticator("{bad-username}", "good-password");
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testMissingUsernameMap() {
+  public void testCtorMissingUsernameMap() {
     Map<String, String> props = new HashMap<>();
     props.put(Authenticator.PROPNAME_PASSWORD, "good-password");
     new BasicAuthenticator(props);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testInvalidUsernameMap() {
+  public void testCtorInvalidUsernameMap() {
     Map<String, String> props = new HashMap<>();
     props.put(Authenticator.PROPNAME_USERNAME, "{bad-username}");
     props.put(Authenticator.PROPNAME_PASSWORD, "good-password");
@@ -69,32 +189,32 @@ public class BasicAuthenticatorTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testInvalidPassword() {
+  public void testCtorInvalidPassword() {
     new BasicAuthenticator("good-username", "{bad-password}");
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testMissingUsername() {
+  public void testCtorMissingUsername() {
     new BasicAuthenticator(null, "good-password");
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testMissingPassword() {
+  public void testCtorMissingPassword() {
     new BasicAuthenticator("good-username", null);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testEmptyUsername() {
+  public void testCtorEmptyUsername() {
     new BasicAuthenticator("", "good-password");
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testEmptyPassword() {
+  public void testCtorEmptyPassword() {
     new BasicAuthenticator("good-username", "");
   }
 
   @Test
-  public void testGoodMapConfig() {
+  public void testCtorGoodConfigMap() {
     Map<String, String> props = new HashMap<>();
     props.put(Authenticator.PROPNAME_USERNAME, "good-username");
     props.put(Authenticator.PROPNAME_PASSWORD, "good-password");

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/BearerTokenAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/BearerTokenAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2015, 2019.
+ * (C) Copyright IBM Corp. 2015, 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -27,6 +27,7 @@ import com.ibm.cloud.sdk.core.security.BearerTokenAuthenticator;
 
 import okhttp3.Request;
 
+@SuppressWarnings("deprecation")
 public class BearerTokenAuthenticatorTest {
 
   @Test
@@ -69,28 +70,41 @@ public class BearerTokenAuthenticatorTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testMissingAccessTokenMap() {
+  public void testCtorMissingAccessTokenMap() {
     Map<String, String> props = new HashMap<>();
     new BearerTokenAuthenticator(props);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testEmptyAccessTokenMap() {
+  public void testCtorEmptyAccessTokenMap() {
     Map<String, String> props = new HashMap<>();
     props.put(Authenticator.PROPNAME_BEARER_TOKEN, "");
     new BearerTokenAuthenticator(props);
   }
 
-  public void testCorrectConfig() {
+  @Test(expected = IllegalArgumentException.class)
+  public void testConfigMissingAccessToken() {
+    Map<String, String> props = new HashMap<>();
+    BearerTokenAuthenticator.fromConfiguration(props);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConfigEmptyAccessToken() {
+    Map<String, String> props = new HashMap<>();
+    props.put(Authenticator.PROPNAME_BEARER_TOKEN, "");
+    BearerTokenAuthenticator.fromConfiguration(props);
+  }
+
+  public void testCtorCorrectConfig() {
     BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator("my-access-token");
     assertEquals(Authenticator.AUTHTYPE_BEARER_TOKEN, authenticator.authenticationType());
     assertEquals("my-access-token", authenticator.getBearerToken());
   }
 
-  public void testCorrectConfigMap() {
+  public void testConfigCorrectConfig() {
     Map<String, String> props = new HashMap<>();
     props.put(Authenticator.PROPNAME_BEARER_TOKEN, "my-access-token");
-    BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(props);
+    BearerTokenAuthenticator authenticator = BearerTokenAuthenticator.fromConfiguration(props);
     assertEquals(Authenticator.AUTHTYPE_BEARER_TOKEN, authenticator.authenticationType());
     assertEquals("my-access-token", authenticator.getBearerToken());
   }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dAuthenticatorLiveTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dAuthenticatorLiveTest.java
@@ -1,0 +1,85 @@
+/**
+ * (C) Copyright IBM Corp. 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.sdk.core.test.security;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.ibm.cloud.sdk.core.http.HttpHeaders;
+import com.ibm.cloud.sdk.core.security.Authenticator;
+import com.ibm.cloud.sdk.core.security.ConfigBasedAuthenticatorFactory;
+
+import okhttp3.Request;
+
+//
+// This class contains an integration test that uses a live CP4D environment.
+// This test is normally @Ignored to avoid trying to run this during automated builds because
+// the CP4D test environment might not be available at all times.
+//
+// In order to test with a live CP4D server, create file "cp4dtest.env" in the project root.
+// It should look like this:
+//
+// CP4DTEST1_AUTH_URL=<url>   e.g. https://cpd350-cpd-cpd350.apps.wml-kf-cluster.os.fyre.ibm.com/icp4d-api
+// CP4DTEST1_AUTH_TYPE=cp4d
+// CP4DTEST1_USERNAME=<username>
+// CP4DTEST1_PASSWORD=<password>
+// CP4DTEST1_AUTH_DISABLE_SSL=true
+//
+// CP4DTEST2_AUTH_URL=<url>   e.g. https://cpd350-cpd-cpd350.apps.wml-kf-cluster.os.fyre.ibm.com/icp4d-api
+// CP4DTEST2_AUTH_TYPE=cp4d
+// CP4DTEST2_USERNAME=<username>
+// CP4DTEST2_APIKEY=<apikey>
+// CP4DTEST2_AUTH_DISABLE_SSL=true
+//
+// Then remove/comment-out the @Ignore annotation below and run the method as a junit test.
+//
+public class Cp4dAuthenticatorLiveTest {
+
+  @Ignore
+  @Test
+  public void testCp4dLiveTokenServer() {
+    System.setProperty("IBM_CREDENTIALS_FILE", "cp4dtest.env");
+
+    Authenticator auth1 = ConfigBasedAuthenticatorFactory.getAuthenticator("cp4dtest1");
+    assertNotNull(auth1);
+
+    Authenticator auth2 = ConfigBasedAuthenticatorFactory.getAuthenticator("cp4dtest2");
+    assertNotNull(auth2);
+
+    Request.Builder requestBuilder;
+
+    // Test the username/password combination.
+    requestBuilder = new Request.Builder().url("https://test.com");
+    auth1.authenticate(requestBuilder);
+    verifyAuthHeader(requestBuilder, "Bearer ");
+
+    // Test the username/apikey combination.
+    requestBuilder = new Request.Builder().url("https://test.com");
+    auth2.authenticate(requestBuilder);
+    verifyAuthHeader(requestBuilder, "Bearer ");
+  }
+
+  // Verify the Authorization header in the specified request builder.
+  private void verifyAuthHeader(Request.Builder builder, String expectedPrefix) {
+    Request request = builder.build();
+    String actualValue = request.header(HttpHeaders.AUTHORIZATION);
+    assertNotNull(actualValue);
+    // System.out.println("Authorization: " + actualValue);
+
+    assertTrue(actualValue.startsWith(expectedPrefix));
+  }
+}

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2015, 2019.
+ * (C) Copyright IBM Corp. 2019, 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -48,6 +48,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ Clock.class })
 @PowerMockIgnore("javax.net.ssl.*")
+@SuppressWarnings("deprecation")
 public class Cp4dAuthenticatorTest extends BaseServiceUnitTest {
 
   // Token with issued-at time of 1574353085 and expiration time of 1574453956
@@ -59,6 +60,7 @@ public class Cp4dAuthenticatorTest extends BaseServiceUnitTest {
   private String url;
   private String testUsername = "test-username";
   private String testPassword = "test-password";
+  private String testApikey = "test-apikey";
 
   @Override
   @Before
@@ -69,66 +71,175 @@ public class Cp4dAuthenticatorTest extends BaseServiceUnitTest {
     refreshedTokenData = loadFixture("src/test/resources/refreshed_cp4d_token.json", Cp4dTokenResponse.class);
   }
 
+
+  //
+  // Tests involving the new Builder class and fromConfiguration() method.
+  //
+
   @Test(expected = IllegalArgumentException.class)
-  public void testMissingURL() {
-    new CloudPakForDataAuthenticator(null, testUsername, testPassword);
+  public void testBuilderMissingURL() {
+    new CloudPakForDataAuthenticator.Builder()
+      .url(null)
+      .username(testUsername)
+      .password(testPassword)
+      .build();
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testEmptyURL() {
-    new CloudPakForDataAuthenticator("", testUsername, testPassword);
+  public void testBuilderEmptyURL() {
+    new CloudPakForDataAuthenticator.Builder()
+      .url("")
+      .username(testUsername)
+      .password(testPassword)
+      .build();
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testMissingUsername() {
-    new CloudPakForDataAuthenticator("https://good-url", null, testPassword);
+  public void testBuilderMissingUsername() {
+    new CloudPakForDataAuthenticator.Builder()
+      .url("https://good-url")
+      .username(null)
+      .password(testPassword)
+      .build();
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testEmptyUsername() {
-    new CloudPakForDataAuthenticator("https://good-url", "", testPassword);
+  public void testBuilderEmptyUsername() {
+    new CloudPakForDataAuthenticator.Builder()
+      .url("https://good-url")
+      .username("")
+      .password(testPassword)
+      .build();
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testMissingUsernameMap() {
+  public void testBuilderMissingPassword() {
+    new CloudPakForDataAuthenticator.Builder()
+      .url("https://good-url")
+      .username(testUsername)
+      .password(null)
+      .build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuilderEmptyPassword() {
+    new CloudPakForDataAuthenticator.Builder()
+      .url("https://good-url")
+      .username(testUsername)
+      .password("")
+      .build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuilderMissingApikey() {
+    new CloudPakForDataAuthenticator.Builder()
+      .url("https://good-url")
+      .username(testUsername)
+      .apikey(null)
+      .build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuilderEmptyApikey() {
+    new CloudPakForDataAuthenticator.Builder()
+      .url("https://good-url")
+      .username(testUsername)
+      .apikey("")
+      .build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConfigMissingUrl() {
+    Map<String, String> props = new HashMap<>();
+    props.put(Authenticator.PROPNAME_URL, null);
+    props.put(Authenticator.PROPNAME_USERNAME, "testUsername");
+    props.put(Authenticator.PROPNAME_PASSWORD, testPassword);
+    CloudPakForDataAuthenticator.fromConfiguration(props);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConfigMissingUsername() {
     Map<String, String> props = new HashMap<>();
     props.put(Authenticator.PROPNAME_URL, "https://good-url");
+    props.put(Authenticator.PROPNAME_USERNAME, null);
     props.put(Authenticator.PROPNAME_PASSWORD, testPassword);
-    new CloudPakForDataAuthenticator(props);
+    CloudPakForDataAuthenticator.fromConfiguration(props);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testEmptyUsernameMap() {
+  public void testConfigMissingPassword() {
     Map<String, String> props = new HashMap<>();
     props.put(Authenticator.PROPNAME_URL, "https://good-url");
-    props.put(Authenticator.PROPNAME_PASSWORD, testPassword);
-    props.put(Authenticator.PROPNAME_USERNAME, "");
-    new CloudPakForDataAuthenticator(props);
+    props.put(Authenticator.PROPNAME_USERNAME, testUsername);
+    props.put(Authenticator.PROPNAME_PASSWORD, null);
+    CloudPakForDataAuthenticator.fromConfiguration(props);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testMissingPassword() {
-    new CloudPakForDataAuthenticator("https://good-url", testUsername, null);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testEmptyPassword() {
-    new CloudPakForDataAuthenticator("https://good-url", testUsername, "");
+  public void testConfigMissingApikey() {
+    Map<String, String> props = new HashMap<>();
+    props.put(Authenticator.PROPNAME_URL, "https://good-url");
+    props.put(Authenticator.PROPNAME_USERNAME, testUsername);
+    props.put(Authenticator.PROPNAME_APIKEY, null);
+    CloudPakForDataAuthenticator.fromConfiguration(props);
   }
 
   @Test
-  public void testCorrectConfig() {
-    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator(url, testUsername, testPassword);
+  public void testBuilderCorrectConfig1() {
+    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator.Builder()
+        .url(url)
+        .username(testUsername)
+        .password(testPassword)
+        .build();
     assertEquals(Authenticator.AUTHTYPE_CP4D, authenticator.authenticationType());
     assertEquals(url, authenticator.getURL());
     assertEquals(testUsername, authenticator.getUsername());
     assertEquals(testPassword, authenticator.getPassword());
+    assertNull(authenticator.getApikey());
     assertFalse(authenticator.getDisableSSLVerification());
     assertNull(authenticator.getHeaders());
   }
 
   @Test
-  public void testCorrectConfigMap() {
+  public void testBuilderCorrectConfig2() {
+    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator.Builder()
+        .url(url)
+        .username(testUsername)
+        .apikey(testApikey)
+        .build();
+    assertEquals(Authenticator.AUTHTYPE_CP4D, authenticator.authenticationType());
+    assertEquals(url, authenticator.getURL());
+    assertEquals(testUsername, authenticator.getUsername());
+    assertNull(authenticator.getPassword());
+    assertEquals(testApikey, authenticator.getApikey());
+    assertFalse(authenticator.getDisableSSLVerification());
+    assertNull(authenticator.getHeaders());
+  }
+
+  @Test
+  public void testBuilderCorrectConfig3() {
+    Map<String, String> expectedHeaders = new HashMap<>();
+    expectedHeaders.put("header1", "value1");
+    expectedHeaders.put("header2", "value2");
+
+    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator.Builder()
+        .url(url)
+        .username(testUsername)
+        .apikey(testApikey)
+        .disableSSLVerification(true)
+        .headers(expectedHeaders)
+        .build();
+    assertEquals(Authenticator.AUTHTYPE_CP4D, authenticator.authenticationType());
+    assertEquals(url, authenticator.getURL());
+    assertEquals(testUsername, authenticator.getUsername());
+    assertNull(authenticator.getPassword());
+    assertEquals(testApikey, authenticator.getApikey());
+    assertTrue(authenticator.getDisableSSLVerification());
+    assertEquals(expectedHeaders, authenticator.getHeaders());
+  }
+
+  @Test
+  public void testConfigCorrectConfig1() {
     Map<String, String> props = new HashMap<>();
     props.put(Authenticator.PROPNAME_URL, url);
     props.put(Authenticator.PROPNAME_PASSWORD, testPassword);
@@ -140,9 +251,33 @@ public class Cp4dAuthenticatorTest extends BaseServiceUnitTest {
     assertEquals(url, authenticator.getURL());
     assertEquals(testUsername, authenticator.getUsername());
     assertEquals(testPassword, authenticator.getPassword());
+    assertNull(authenticator.getApikey());
     assertTrue(authenticator.getDisableSSLVerification());
     assertNull(authenticator.getHeaders());
   }
+
+  @Test
+  public void testConfigCorrectConfig2() {
+    Map<String, String> props = new HashMap<>();
+    props.put(Authenticator.PROPNAME_URL, url);
+    props.put(Authenticator.PROPNAME_USERNAME, testUsername);
+    props.put(Authenticator.PROPNAME_APIKEY, testApikey);
+    props.put(Authenticator.PROPNAME_DISABLE_SSL, "false");
+
+    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator(props);
+    assertEquals(Authenticator.AUTHTYPE_CP4D, authenticator.authenticationType());
+    assertEquals(url, authenticator.getURL());
+    assertEquals(testUsername, authenticator.getUsername());
+    assertNull(authenticator.getPassword());
+    assertEquals(testApikey, authenticator.getApikey());
+    assertFalse(authenticator.getDisableSSLVerification());
+    assertNull(authenticator.getHeaders());
+  }
+
+
+  //
+  // Tests involving interactions with a mocked token service.
+  //
 
   @Test
   public void testAuthenticateNewAndStoredToken() {
@@ -152,22 +287,23 @@ public class Cp4dAuthenticatorTest extends BaseServiceUnitTest {
     PowerMockito.mockStatic(Clock.class);
     PowerMockito.when(Clock.getCurrentTimeInSeconds()).thenReturn((long) 100);
 
-    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator(url, testUsername, testPassword);
-    authenticator.setDisableSSLVerification(true);
-    Request.Builder requestBuilder = new Request.Builder().url("https://test.com");
+    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator.Builder()
+        .url(url)
+        .username(testUsername)
+        .password(testPassword)
+        .disableSSLVerification(true)
+        .build();
+    Request.Builder requestBuilder;
 
     // Authenticator should request new, valid token.
+    requestBuilder = new Request.Builder().url("https://test.com");
     authenticator.authenticate(requestBuilder);
-
-    Request request = requestBuilder.build();
-    assertEquals("Bearer " + tokenData.getAccessToken(), request.header(HttpHeaders.AUTHORIZATION));
+    verifyAuthHeader(requestBuilder, "Bearer " + tokenData.getToken());
 
     // Authenticator should just return the same token this time since we have a valid one stored.
-    Request.Builder newBuilder = request.newBuilder();
-    authenticator.authenticate(newBuilder);
-
-    Request newRequest = newBuilder.build();
-    assertEquals("Bearer " + tokenData.getAccessToken(), newRequest.header(HttpHeaders.AUTHORIZATION));
+    requestBuilder = new Request.Builder().url("https://test.com");
+    authenticator.authenticate(requestBuilder);
+    verifyAuthHeader(requestBuilder, "Bearer " + tokenData.getToken());
   }
 
   @Test
@@ -178,19 +314,24 @@ public class Cp4dAuthenticatorTest extends BaseServiceUnitTest {
     PowerMockito.mockStatic(Clock.class);
     PowerMockito.when(Clock.getCurrentTimeInSeconds()).thenReturn((long) 1800000000);
 
-    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator(url, testUsername, testPassword);
-    Request.Builder requestBuilder = new Request.Builder().url("https://test.com");
+    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator.Builder()
+        .url(url)
+        .username(testUsername)
+        .password(testPassword)
+        .build();
+    Request.Builder requestBuilder;
 
     // This will bootstrap the test by forcing the Authenticator to store the expired token
     // set above in the mock server.
+    requestBuilder = new Request.Builder().url("https://test.com");
     authenticator.authenticate(requestBuilder);
 
     // Authenticator should detect the expiration and request a new access token when we call authenticate() again.
     server.enqueue(jsonResponse(refreshedTokenData));
-    authenticator.authenticate(requestBuilder);
 
-    Request request = requestBuilder.build();
-    assertEquals("Bearer " + refreshedTokenData.getAccessToken(), request.header(HttpHeaders.AUTHORIZATION));
+    requestBuilder = new Request.Builder().url("https://test.com");
+    authenticator.authenticate(requestBuilder);
+    verifyAuthHeader(requestBuilder, "Bearer " + refreshedTokenData.getToken());
   }
 
   @Test
@@ -201,32 +342,35 @@ public class Cp4dAuthenticatorTest extends BaseServiceUnitTest {
     PowerMockito.mockStatic(Clock.class);
     PowerMockito.when(Clock.getCurrentTimeInSeconds()).thenReturn((long) 1574453700);
 
-    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator(url, testUsername, testPassword);
-    authenticator.setDisableSSLVerification(true);
-    Request.Builder requestBuilder = new Request.Builder().url("https://test.com");
+    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator.Builder()
+        .url(url)
+        .username(testUsername)
+        .apikey(testApikey)
+        .disableSSLVerification(true)
+        .build();
+    Request.Builder requestBuilder;
 
     // This will bootstrap the test by forcing the Authenticator to store the token needing refreshed, which was
     // set above in the mock server.
+    requestBuilder = new Request.Builder().url("https://test.com");
     authenticator.authenticate(requestBuilder);
 
     // Authenticator should detect the need to refresh and request a new access token IN THE BACKGROUND when we call
     // authenticate() again. The immediate response should be the token which was already stored, since it's not yet
     // expired.
     server.enqueue(jsonResponse(refreshedTokenData).setBodyDelay(2, TimeUnit.SECONDS));
-    authenticator.authenticate(requestBuilder);
 
-    Request request = requestBuilder.build();
-    assertEquals("Bearer " + tokenData.getAccessToken(), request.header(HttpHeaders.AUTHORIZATION));
+    requestBuilder = new Request.Builder().url("https://test.com");
+    authenticator.authenticate(requestBuilder);
+    verifyAuthHeader(requestBuilder, "Bearer " + tokenData.getToken());
 
     // Sleep to wait out the background refresh of our access token.
     Thread.sleep(3000);
 
     // Next request should use the refreshed token.
-    Request.Builder newBuilder = request.newBuilder();
-    authenticator.authenticate(newBuilder);
-
-    Request newRequest = newBuilder.build();
-    assertEquals("Bearer " + refreshedTokenData.getAccessToken(), newRequest.header(HttpHeaders.AUTHORIZATION));
+    requestBuilder = new Request.Builder().url("https://test.com");
+    authenticator.authenticate(requestBuilder);
+    verifyAuthHeader(requestBuilder, "Bearer " + refreshedTokenData.getToken());
   }
 
   @Test
@@ -237,21 +381,24 @@ public class Cp4dAuthenticatorTest extends BaseServiceUnitTest {
     PowerMockito.mockStatic(Clock.class);
     PowerMockito.when(Clock.getCurrentTimeInSeconds()).thenReturn((long) 100);
 
-    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator(url, testUsername, testPassword);
-    authenticator.setDisableSSLVerification(true);
+    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator.Builder()
+        .url(url)
+        .username(testUsername)
+        .apikey(testApikey)
+        .disableSSLVerification(true)
+        .build();
 
     Map<String, String> headers = new HashMap<>();
     headers.put("header1", "value1");
     headers.put("header2", "value2");
     authenticator.setHeaders(headers);
 
-    Request.Builder requestBuilder = new Request.Builder().url("https://test.com");
+    Request.Builder requestBuilder;
 
     // Authenticator should request new, valid token.
+    requestBuilder = new Request.Builder().url("https://test.com");
     authenticator.authenticate(requestBuilder);
-
-    Request request = requestBuilder.build();
-    assertEquals("Bearer " + tokenData.getAccessToken(), request.header(HttpHeaders.AUTHORIZATION));
+    verifyAuthHeader(requestBuilder, "Bearer " + tokenData.getToken());
 
     // Now do some validation on the mock request sent to the token server.
     RecordedRequest tokenServerRequest = server.takeRequest();
@@ -262,11 +409,9 @@ public class Cp4dAuthenticatorTest extends BaseServiceUnitTest {
     assertEquals("value2", actualHeaders.get("header2"));
 
     // Authenticator should just return the same token this time since we have a valid one stored.
-    Request.Builder newBuilder = request.newBuilder();
-    authenticator.authenticate(newBuilder);
-
-    Request newRequest = newBuilder.build();
-    assertEquals("Bearer " + tokenData.getAccessToken(), newRequest.header(HttpHeaders.AUTHORIZATION));
+    requestBuilder = new Request.Builder().url("https://test.com");
+    authenticator.authenticate(requestBuilder);
+    verifyAuthHeader(requestBuilder, "Bearer " + tokenData.getToken());
   }
 
   @Test
@@ -277,7 +422,11 @@ public class Cp4dAuthenticatorTest extends BaseServiceUnitTest {
     PowerMockito.mockStatic(Clock.class);
     PowerMockito.when(Clock.getCurrentTimeInSeconds()).thenReturn((long) 100);
 
-    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator(url, testUsername, testPassword);
+    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator.Builder()
+        .url(url)
+        .username(testUsername)
+        .password(testPassword)
+        .build();
 
     Request.Builder requestBuilder = new Request.Builder().url("https://test.com");
 
@@ -300,7 +449,11 @@ public class Cp4dAuthenticatorTest extends BaseServiceUnitTest {
     PowerMockito.mockStatic(Clock.class);
     PowerMockito.when(Clock.getCurrentTimeInSeconds()).thenReturn((long) 100);
 
-    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator(url, testUsername, testPassword);
+    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator.Builder()
+        .url(url)
+        .username(testUsername)
+        .apikey(testApikey)
+        .build();
 
     Request.Builder requestBuilder = new Request.Builder().url("https://test.com");
 
@@ -315,5 +468,94 @@ public class Cp4dAuthenticatorTest extends BaseServiceUnitTest {
     } catch (Throwable t) {
       fail("Expected RuntimeException, not " + t.getClass().getSimpleName());
     }
+  }
+
+  // Verify the Authorization header in the specified request builder.
+  private void verifyAuthHeader(Request.Builder builder, String expectedPrefix) {
+    Request request = builder.build();
+    String actualValue = request.header(HttpHeaders.AUTHORIZATION);
+    assertNotNull(actualValue);
+
+    assertTrue(actualValue.startsWith(expectedPrefix));
+  }
+
+
+  //
+  // Tests involving the deprecated ctors.
+  //
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCtorMissingURL() {
+    new CloudPakForDataAuthenticator(null, testUsername, testPassword);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCtorEmptyURL() {
+    new CloudPakForDataAuthenticator("", testUsername, testPassword);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCtorMissingUsername() {
+    new CloudPakForDataAuthenticator("https://good-url", null, testPassword);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCtorEmptyUsername() {
+    new CloudPakForDataAuthenticator("https://good-url", "", testPassword);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCtorMissingPassword() {
+    new CloudPakForDataAuthenticator("https://good-url", testUsername, null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCtorEmptyPassword() {
+    new CloudPakForDataAuthenticator("https://good-url", testUsername, "");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCtorMissingUsernameMap() {
+    Map<String, String> props = new HashMap<>();
+    props.put(Authenticator.PROPNAME_URL, "https://good-url");
+    props.put(Authenticator.PROPNAME_PASSWORD, testPassword);
+    new CloudPakForDataAuthenticator(props);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCtorEmptyUsernameMap() {
+    Map<String, String> props = new HashMap<>();
+    props.put(Authenticator.PROPNAME_URL, "https://good-url");
+    props.put(Authenticator.PROPNAME_PASSWORD, testPassword);
+    props.put(Authenticator.PROPNAME_USERNAME, "");
+    new CloudPakForDataAuthenticator(props);
+  }
+
+  @Test
+  public void testCtorCorrectConfig() {
+    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator(url, testUsername, testPassword);
+    assertEquals(Authenticator.AUTHTYPE_CP4D, authenticator.authenticationType());
+    assertEquals(url, authenticator.getURL());
+    assertEquals(testUsername, authenticator.getUsername());
+    assertEquals(testPassword, authenticator.getPassword());
+    assertFalse(authenticator.getDisableSSLVerification());
+    assertNull(authenticator.getHeaders());
+  }
+
+  @Test
+  public void testCtorCorrectConfigMap() {
+    Map<String, String> props = new HashMap<>();
+    props.put(Authenticator.PROPNAME_URL, url);
+    props.put(Authenticator.PROPNAME_PASSWORD, testPassword);
+    props.put(Authenticator.PROPNAME_USERNAME, testUsername);
+    props.put(Authenticator.PROPNAME_DISABLE_SSL, "true");
+
+    CloudPakForDataAuthenticator authenticator = new CloudPakForDataAuthenticator(props);
+    assertEquals(Authenticator.AUTHTYPE_CP4D, authenticator.authenticationType());
+    assertEquals(url, authenticator.getURL());
+    assertEquals(testUsername, authenticator.getUsername());
+    assertEquals(testPassword, authenticator.getPassword());
+    assertTrue(authenticator.getDisableSSLVerification());
+    assertNull(authenticator.getHeaders());
   }
 }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/IamAuthenticatorLiveTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/IamAuthenticatorLiveTest.java
@@ -1,0 +1,80 @@
+/**
+ * (C) Copyright IBM Corp. 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.sdk.core.test.security;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.ibm.cloud.sdk.core.http.HttpHeaders;
+import com.ibm.cloud.sdk.core.security.Authenticator;
+import com.ibm.cloud.sdk.core.security.ConfigBasedAuthenticatorFactory;
+
+import okhttp3.Request;
+
+//
+// This class contains an integration test that uses the live IAM token service.
+// This test is normally @Ignored to avoid trying to run this during automated builds.
+//
+// In order to run these tests, ceate file "cp4dtest.env" in the project root.
+// It should look like this:
+//
+// IAMTEST1_AUTH_URL=<prod iam url>   e.g. https://iam.cloud.ibm.com
+// IAMTEST1_AUTH_TYPE=iam
+// IAMTEST1_APIKEY=<apikey>
+//
+// IAMTEST2_AUTH_URL=<test iam url>   e.g. https://iam.test.cloud.ibm.com
+// IAMTEST2_AUTH_TYPE=iam
+// IAMTEST2_APIKEY=<apikey>
+//
+// Then remove/comment-out the @Ignore annotation below and run the method as a junit test.
+//
+public class IamAuthenticatorLiveTest {
+
+  @Ignore
+  @Test
+  public void testIamLiveTokenServer() {
+    System.setProperty("IBM_CREDENTIALS_FILE", "iamtest.env");
+
+    Authenticator auth1 = ConfigBasedAuthenticatorFactory.getAuthenticator("iamtest1");
+    assertNotNull(auth1);
+
+    Authenticator auth2 = ConfigBasedAuthenticatorFactory.getAuthenticator("iamtest2");
+    assertNotNull(auth2);
+
+    Request.Builder requestBuilder;
+
+    // Test the username/password combination.
+    requestBuilder = new Request.Builder().url("https://test.com");
+    auth1.authenticate(requestBuilder);
+    verifyAuthHeader(requestBuilder, "Bearer ");
+
+    // Test the username/apikey combination.
+    requestBuilder = new Request.Builder().url("https://test.com");
+    auth2.authenticate(requestBuilder);
+    verifyAuthHeader(requestBuilder, "Bearer ");
+  }
+
+  // Verify the Authorization header in the specified request builder.
+  private void verifyAuthHeader(Request.Builder builder, String expectedPrefix) {
+    Request request = builder.build();
+    String actualValue = request.header(HttpHeaders.AUTHORIZATION);
+    assertNotNull(actualValue);
+    System.out.println("Authorization: " + actualValue);
+
+    assertTrue(actualValue.startsWith(expectedPrefix));
+  }
+}

--- a/src/test/resources/cp4d_token.json
+++ b/src/test/resources/cp4d_token.json
@@ -1,21 +1,5 @@
 {
-  "username": "admin",
-  "role": "Admin",
-  "permissions": [
-    "administrator",
-    "manage_catalog",
-    "access_catalog",
-    "manage_policies",
-    "access_policies",
-    "virtualize_transform",
-    "can_provision",
-    "deployment_admin"
-  ],
-  "sub": "admin",
-  "iss": "test",
-  "aud": "DSX",
-  "uid": "999",
-  "accessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImFkbWluIiwicm9sZSI6IkFkbWluIiwicGVybWlzc2lvbnMiOlsiYWRtaW5pc3RyYXRvciIsIm1hbmFnZV9jYXRhbG9nIiwiYWNjZXNzX2NhdGFsb2ciLCJtYW5hZ2VfcG9saWNpZXMiLCJhY2Nlc3NfcG9saWNpZXMiLCJ2aXJ0dWFsaXplX3RyYW5zZm9ybSIsImNhbl9wcm92aXNpb24iLCJkZXBsb3ltZW50X2FkbWluIl0sInN1YiI6ImFkbWluIiwiaXNzIjoiS05PWFNTTyIsImF1ZCI6IkRTWCIsInVpZCI6Ijk5OSIsImlhdCI6MTU3NDM1MzA4NSwiZXhwIjoxNTc0NDUzOTU2LCJqdGkiOiJkN2YzNTAzYi0zMzQ0LTRjOGYtOGE4NC01OTM2OGQzMjZkYTcifQ.8JVnHFS7o9wcGcBhD_eS5qslxrO9YpmQtzy8-xhjPxA",
+  "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImFkbWluIiwicm9sZSI6IkFkbWluIiwicGVybWlzc2lvbnMiOlsiYWRtaW5pc3RyYXRvciIsIm1hbmFnZV9jYXRhbG9nIiwiYWNjZXNzX2NhdGFsb2ciLCJtYW5hZ2VfcG9saWNpZXMiLCJhY2Nlc3NfcG9saWNpZXMiLCJ2aXJ0dWFsaXplX3RyYW5zZm9ybSIsImNhbl9wcm92aXNpb24iLCJkZXBsb3ltZW50X2FkbWluIl0sInN1YiI6ImFkbWluIiwiaXNzIjoiS05PWFNTTyIsImF1ZCI6IkRTWCIsInVpZCI6Ijk5OSIsImlhdCI6MTU3NDM1MzA4NSwiZXhwIjoxNTc0NDUzOTU2LCJqdGkiOiJkN2YzNTAzYi0zMzQ0LTRjOGYtOGE4NC01OTM2OGQzMjZkYTcifQ.8JVnHFS7o9wcGcBhD_eS5qslxrO9YpmQtzy8-xhjPxA",
   "_messageCode_": "success",
   "message": "success"
 }

--- a/src/test/resources/refreshed_cp4d_token.json
+++ b/src/test/resources/refreshed_cp4d_token.json
@@ -1,21 +1,5 @@
 {
-  "username": "admin",
-  "role": "Admin",
-  "permissions": [
-    "administrator",
-    "manage_catalog",
-    "access_catalog",
-    "manage_policies",
-    "access_policies",
-    "virtualize_transform",
-    "can_provision",
-    "deployment_admin"
-  ],
-  "sub": "admin",
-  "iss": "test",
-  "aud": "DSX",
-  "uid": "999",
-  "accessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImFkbWluIiwicm9sZSI6IkFkbWluIiwicGVybWlzc2lvbnMiOlsiYWRtaW5pc3RyYXRvciIsIm1hbmFnZV9jYXRhbG9nIiwiYWNjZXNzX2NhdGFsb2ciLCJtYW5hZ2VfcG9saWNpZXMiLCJhY2Nlc3NfcG9saWNpZXMiLCJ2aXJ0dWFsaXplX3RyYW5zZm9ybSIsImNhbl9wcm92aXNpb24iLCJkZXBsb3ltZW50X2FkbWluIl0sInN1YiI6ImFkbWluIiwiaXNzIjoiS05PWFNTTyIsImF1ZCI6IkRTWCIsInVpZCI6Ijk5OSIsImlhdCI6MTYwMjc4ODY0NSwiZXhwIjoxNTc0NDU0MTYyLCJqdGkiOiJkN2YzNTAzYi0zMzQ0LTRjOGYtOGE4NC01OTM2OGQzMjZkYTcifQ.OHlcts_y6QhpwRbtEOAJkukkoAg6HW8f8ZJ7k4GfgmQ",
+  "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImFkbWluIiwicm9sZSI6IkFkbWluIiwicGVybWlzc2lvbnMiOlsiYWRtaW5pc3RyYXRvciIsIm1hbmFnZV9jYXRhbG9nIiwiYWNjZXNzX2NhdGFsb2ciLCJtYW5hZ2VfcG9saWNpZXMiLCJhY2Nlc3NfcG9saWNpZXMiLCJ2aXJ0dWFsaXplX3RyYW5zZm9ybSIsImNhbl9wcm92aXNpb24iLCJkZXBsb3ltZW50X2FkbWluIl0sInN1YiI6ImFkbWluIiwiaXNzIjoiS05PWFNTTyIsImF1ZCI6IkRTWCIsInVpZCI6Ijk5OSIsImlhdCI6MTYwMjc4ODY0NSwiZXhwIjoxNTc0NDU0MTYyLCJqdGkiOiJkN2YzNTAzYi0zMzQ0LTRjOGYtOGE4NC01OTM2OGQzMjZkYTcifQ.OHlcts_y6QhpwRbtEOAJkukkoAg6HW8f8ZJ7k4GfgmQ",
   "_messageCode_": "success",
   "message": "success"
 }


### PR DESCRIPTION
The main focus of this change is to enhance the CloudPakForDataAuthentictor
implementation to support the official "POST /v1/authorize" operation for
obtaining an access token.   This includes support for using either a password
or an apikey when obtaining the access token from the token service.

In addition, a new Builder class was introduced which provides a more user-friendly
way to construct instances of CloudPakForDataAuthenticator.  The "fromConfiguration"
method was also added to replace the (now deprecated) map-based ctor.

In order to keep the IamAuthenticator class in sync with CloudPakForDataAuthenticator,
the Builder class and fromConfiguration() method were also added to IamAuthenticator.
In the case of both authenticators, the existing set of constructors are still supported
but are now deprecated and will be removed in the next major release of the Java core.