### PR TITLE
build: upgrade okhttp3 dependency to v4.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <checkstyle-version>8.41</checkstyle-version>
         <jacoco-plugin-version>0.8.3</jacoco-plugin-version>
         <compiler-plugin-version>3.8.0</compiler-plugin-version>
-        <okhttp3-version>4.9.0</okhttp3-version>
+        <okhttp3-version>4.9.1</okhttp3-version>
         <logback-version>1.2.3</logback-version>
         <guava-version>30.1.1-jre</guava-version>
         <gson-version>2.8.6</gson-version>


### PR DESCRIPTION
This PR upgrades our okhttp3 dependency to the latest stable version (4.9.1).