### PR TITLE
test: add tests involving Host header

### DIFF
--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dServiceAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dServiceAuthenticatorTest.java
@@ -521,6 +521,7 @@ public class Cp4dServiceAuthenticatorTest extends BaseServiceUnitTest {
     Map<String, String> headers = new HashMap<>();
     headers.put("header1", "value1");
     headers.put("header2", "value2");
+    headers.put("Host", "cp4d.cloud.ibm.com:81");
     authenticator.setHeaders(headers);
 
     Request.Builder requestBuilder;
@@ -537,6 +538,7 @@ public class Cp4dServiceAuthenticatorTest extends BaseServiceUnitTest {
     Headers actualHeaders = tokenServerRequest.getHeaders();
     assertEquals("value1", actualHeaders.get("header1"));
     assertEquals("value2", actualHeaders.get("header2"));
+    assertEquals("cp4d.cloud.ibm.com:81", actualHeaders.get("Host"));
 
     // Authenticator should just return the same token this time since we have a valid one stored.
     requestBuilder = new Request.Builder().url("https://test.com");

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/IamAuthenticatorLiveTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/IamAuthenticatorLiveTest.java
@@ -16,6 +16,9 @@ package com.ibm.cloud.sdk.core.test.security;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -24,6 +27,7 @@ import com.ibm.cloud.sdk.core.security.Authenticator;
 import com.ibm.cloud.sdk.core.security.ConfigBasedAuthenticatorFactory;
 import com.ibm.cloud.sdk.core.security.IamAuthenticator;
 import com.ibm.cloud.sdk.core.security.IamToken;
+import com.ibm.cloud.sdk.core.util.CredentialUtils;
 
 import okhttp3.Request;
 
@@ -80,6 +84,37 @@ public class IamAuthenticatorLiveTest {
 
     // This check is to ensure we get back a valid refresh token rather than something like "not_supported".
     assertTrue(refreshToken.length() > 20);
+  }
+
+  @Ignore
+  @Test
+  public void testIamLiveTokenServerHeaders() {
+    System.setProperty("IBM_CREDENTIALS_FILE", "iamtest.env");
+
+    Map<String, String> config = CredentialUtils.getServiceProperties("iamtest1");
+    assertNotNull(config);
+
+    String apiKey = config.get("APIKEY");
+    assertNotNull(apiKey);
+
+    String authURL = config.get("AUTH_URL");
+    assertNotNull(authURL);
+
+    Map<String, String> headers = new HashMap<>();
+    headers.put("Host", "iam.cloud.ibm.com:443");
+
+    IamAuthenticator authenticator = new IamAuthenticator.Builder()
+        .apikey(apiKey)
+        .url(authURL)
+        .headers(headers)
+        .build();
+
+    Request.Builder requestBuilder;
+
+    // Perform a test using the "production" IAM token server.
+    requestBuilder = new Request.Builder().url("https://test.com");
+    authenticator.authenticate(requestBuilder);
+    verifyAuthHeader(requestBuilder, "Bearer ");
   }
 
   // Verify the Authorization header in the specified request builder.

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/IamAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/IamAuthenticatorTest.java
@@ -320,6 +320,7 @@ public class IamAuthenticatorTest extends BaseServiceUnitTest {
     Map<String, String> headers = new HashMap<>();
     headers.put("header1", "value1");
     headers.put("header2", "value2");
+    headers.put("Host", "iam.cloud.ibm.com:81");
     IamAuthenticator authenticator = new IamAuthenticator(API_KEY, url, null, null, false, headers);
 
     Request.Builder requestBuilder = new Request.Builder().url("https://test.com");
@@ -335,6 +336,7 @@ public class IamAuthenticatorTest extends BaseServiceUnitTest {
     Headers actualHeaders = tokenServerRequest.getHeaders();
     assertEquals("value1", actualHeaders.get("header1"));
     assertEquals("value2", actualHeaders.get("header2"));
+    assertEquals("iam.cloud.ibm.com:81", actualHeaders.get("Host"));
 
     // Authenticator should just return the same token this time since we have a valid one stored.
     requestBuilder = new Request.Builder().url("https://test.com");

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/HeadersTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/HeadersTest.java
@@ -13,6 +13,12 @@
 
 package com.ibm.cloud.sdk.core.test.service;
 
+import static com.ibm.cloud.sdk.core.http.HttpHeaders.CONTENT_TYPE;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
 import com.ibm.cloud.sdk.core.http.HttpMediaType;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
 import com.ibm.cloud.sdk.core.http.ServiceCall;
@@ -22,14 +28,10 @@ import com.ibm.cloud.sdk.core.service.BaseService;
 import com.ibm.cloud.sdk.core.service.model.GenericModel;
 import com.ibm.cloud.sdk.core.test.BaseServiceUnitTest;
 import com.ibm.cloud.sdk.core.util.ResponseConverterUtils;
+
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.Before;
-import org.junit.Test;
-
-import static com.ibm.cloud.sdk.core.http.HttpHeaders.CONTENT_TYPE;
-import static org.junit.Assert.assertTrue;
 
 public class HeadersTest extends BaseServiceUnitTest {
 
@@ -80,6 +82,45 @@ public class HeadersTest extends BaseServiceUnitTest {
         .addHeader(headerName, "test")
         .execute();
     final RecordedRequest request = server.takeRequest();
-    assertTrue(request.getHeader(headerName) != null);
+    assertEquals(request.getHeader(headerName), "test");
+  }
+
+  /**
+   * Test setting the Host header to something other than the host:port
+   * contained in the request URL.
+   *
+   * @throws InterruptedException
+   */
+  @Test
+  public void testAddHostHeader() throws InterruptedException {
+    server.enqueue(new MockResponse()
+        .addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON)
+        .setBody("{\"test_key\": \"test_value\"}"));
+
+    service.testMethod()
+        .addHeader("Host", "test.ibm.com:80")
+        .execute();
+    final RecordedRequest request = server.takeRequest();
+    assertEquals(request.getHeader("Host"), "test.ibm.com:80");
+  }
+
+  /**
+   * Test that the Host header is set implicitly to be the host:port
+   * value contained in the request URL.
+   *
+   * @throws InterruptedException
+   */
+  @Test
+  public void testImplicitHostHeader() throws InterruptedException {
+    HttpUrl url = server.url("");
+    String expectedHostHeaderValue = url.host() + ":" + String.valueOf(url.port());
+    System.out.println("expectedHostHeaderValue: " + expectedHostHeaderValue);
+    server.enqueue(new MockResponse()
+        .addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON)
+        .setBody("{\"test_key\": \"test_value\"}"));
+
+    service.testMethod().execute();
+    final RecordedRequest request = server.takeRequest();
+    assertEquals(request.getHeader("Host"), expectedHostHeaderValue);
   }
 }


### PR DESCRIPTION
This commit adds tests to verify that the "Host" request
header can be explicitly set in the following ways:
- As part of a service request (request builder)
- As a custom header while constructing an IAM Authenticator instance
- As a custom header while constructing a CP4D Authenticator instance