### PR TITLE
fix: change method name to `constructServiceUrl`

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
@@ -241,9 +241,7 @@ public abstract class BaseService {
   }
 
   /**
-   * @deprecated
-   * Deprecated in favor of `constructServiceUrl`.
-   * This naming convention is consistent with `setServiceUrl`.
+   * @deprecated use constructServiceUrl() instead.
    */
   @Deprecated
   public static String constructServiceURL(

--- a/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
@@ -196,7 +196,7 @@ public abstract class BaseService {
    *  the default variable value will be used instead.
    * @return the formatted URL with all variable placeholders replaced by values.
    */
-  public static String constructServiceURL(
+  public static String constructServiceUrl(
     String parameterizedUrl,
     Map<String, String> defaultUrlVariables,
     Map<String, String> providedUrlVariables
@@ -238,6 +238,20 @@ public abstract class BaseService {
       formattedUrl = formattedUrl.replaceAll("\\{" + name + "}", formatValue);
     }
     return formattedUrl;
+  }
+
+  /**
+   * @deprecated
+   * Deprecated in favor of `constructServiceUrl`.
+   * This naming convention is consistent with `setServiceUrl`.
+   */
+  @Deprecated
+  public static String constructServiceURL(
+    String parameterizedUrl,
+    Map<String, String> defaultUrlVariables,
+    Map<String, String> providedUrlVariables
+  ) {
+    return BaseService.constructServiceUrl(parameterizedUrl, defaultUrlVariables, providedUrlVariables);
   }
 
   /**

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/ParameterizedUrlTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/ParameterizedUrlTest.java
@@ -28,7 +28,7 @@ public class ParameterizedUrlTest {
 
   @Test
   public void testConstructServiceURLWithNull() {
-    String constructedUrl = BaseService.constructServiceURL(parameterizedUrl, defaultUrlVariables, null);
+    String constructedUrl = BaseService.constructServiceUrl(parameterizedUrl, defaultUrlVariables, null);
     assertEquals(constructedUrl, "http://ibm.com:9300");
   }
 
@@ -39,7 +39,7 @@ public class ParameterizedUrlTest {
     providedUrlVariables.put("scheme", "https");
     providedUrlVariables.put("port", "22");
 
-    String constructedUrl = BaseService.constructServiceURL(
+    String constructedUrl = BaseService.constructServiceUrl(
       parameterizedUrl, defaultUrlVariables, providedUrlVariables
     );
     assertEquals(constructedUrl, "https://ibm.com:22");
@@ -53,7 +53,7 @@ public class ParameterizedUrlTest {
     providedUrlVariables.put("domain", "google.com");
     providedUrlVariables.put("port", "22");
 
-    String constructedUrl = BaseService.constructServiceURL(
+    String constructedUrl = BaseService.constructServiceUrl(
       parameterizedUrl, defaultUrlVariables, providedUrlVariables
     );
     assertEquals(constructedUrl, "https://google.com:22");
@@ -70,6 +70,6 @@ public class ParameterizedUrlTest {
     Map<String, String> providedUrlVariables = new HashMap<>();
     providedUrlVariables.put("server", "value");
 
-    BaseService.constructServiceURL(parameterizedUrl, defaultUrlVariables, providedUrlVariables);
+    BaseService.constructServiceUrl(parameterizedUrl, defaultUrlVariables, providedUrlVariables);
   }
 }


### PR DESCRIPTION
This is consistent with the naming convention of `setServiceUrl`.