### PR TITLE
fix: bump maven-compiler-plugin source and target version to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,8 +315,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin-version}</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This PR increases the `source` and `target` version of maven-compiler-plugin to `1.8`.

The whole platform SDK test set was executed on my local machine using a snapshot build, including this change, from the core and all tests passed.