### PR TITLE
feat(BaseService): remove final modifier from createServiceCall

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
@@ -322,7 +322,7 @@ public abstract class BaseService {
    * @param converter the converter
    * @return the service call
    */
-  protected final <T> ServiceCall<T> createServiceCall(final Request request, final ResponseConverter<T> converter) {
+  protected <T> ServiceCall<T> createServiceCall(final Request request, final ResponseConverter<T> converter) {
     final Call call = createCall(request);
     return new IBMCloudSDKServiceCall<>(call, converter);
   }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/BaseServiceTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/BaseServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2015, 2019.
+ * (C) Copyright IBM Corp. 2015, 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -22,12 +22,15 @@ import org.testng.annotations.Test;
 
 import com.ibm.cloud.sdk.core.http.HttpClientSingleton;
 import com.ibm.cloud.sdk.core.http.HttpConfigOptions;
+import com.ibm.cloud.sdk.core.http.ResponseConverter;
+import com.ibm.cloud.sdk.core.http.ServiceCall;
 import com.ibm.cloud.sdk.core.http.gzip.GzipRequestInterceptor;
 import com.ibm.cloud.sdk.core.security.NoAuthAuthenticator;
 import com.ibm.cloud.sdk.core.service.BaseService;
-
+import com.ibm.cloud.sdk.core.util.ResponseConverterUtils;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
 import okhttp3.internal.tls.OkHostnameVerifier;
 
 /**
@@ -182,5 +185,26 @@ public class BaseServiceTest {
     assertEquals(60 * 1000, client.connectTimeoutMillis());
     assertEquals(60 * 1000, client.writeTimeoutMillis());
     assertEquals(5 * 60 * 1000, client.readTimeoutMillis());
+  }
+
+  @Test
+  public void testCreateServiceCallOverride() {
+    class ExtendingService extends BaseService {
+
+      @Override
+      protected <T> ServiceCall<T> createServiceCall(final Request request, final ResponseConverter<T> converter) {
+        // For test purposes override to just return null
+        return null;
+      }
+
+      public ServiceCall<String> testOperation() {
+        Request r = new Request.Builder().url("https://foo.example").get().build();
+        return createServiceCall(r, ResponseConverterUtils.getString());
+      }
+    };
+    ExtendingService extendingService = new ExtendingService();
+    ServiceCall<String> testCall = extendingService.testOperation();
+    // Assert that the override was in place
+    assertNull("The service call should have been overridden to return null.", testCall);
   }
 }


### PR DESCRIPTION
Remove the `final` modifier from the `BaseService#createServiceCall` to allow extending services to override.

This provides a hook point that can be used to modify every request earlier than an interceptor is able to do so.

Added a test that will fail to compile if the final modifier is re-added inadvertently. The assertion itself is slightly pointless as it effectively validates the JVM's override functionality, but it seems nicer than having a "compile-only" test.

Note also as per [JLS 13.4.17](https://docs.oracle.com/javase/specs/jls/se7/html/jls-13.html#jls-13.4.17) is a binary compatible change.