### PR TITLE
test: unit tests covering LongToDateTypeAdapter

### DIFF
--- a/src/test/java/com/ibm/cloud/sdk/core/util/LongToDateTimeAdapterTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/LongToDateTimeAdapterTest.java
@@ -82,11 +82,7 @@ public class LongToDateTimeAdapterTest {
     String json = String.format("{\"birth_date\":\"\", \"name\":\"%s\"}", name);
 
     // Act
-    LongToDateTimeAdapterModel model = gson.fromJson(json, LongToDateTimeAdapterModel.class);
-
-    // Assert
-    assertNull(model.birthDate);
-    assertEquals(model.name, "Lorem");
+    gson.fromJson(json, LongToDateTimeAdapterModel.class);
   }
 
   @Test(expectedExceptions = NumberFormatException.class)
@@ -95,11 +91,7 @@ public class LongToDateTimeAdapterTest {
     String json = String.format("{\"birth_date\":\" \", \"name\":\"%s\"}", name);
 
     // Act
-    LongToDateTimeAdapterModel model = gson.fromJson(json, LongToDateTimeAdapterModel.class);
-
-    // Assert
-    assertNull(model.birthDate);
-    assertEquals(model.name, "Lorem");
+    gson.fromJson(json, LongToDateTimeAdapterModel.class);
   }
 
   @Test
@@ -114,7 +106,7 @@ public class LongToDateTimeAdapterTest {
     // Assert
     assertNotNull(model.birthDate);
     assertEquals(model.birthDate.getTime(), date.getTime());
-    assertEquals(model.name, "Lorem");
+    assertEquals(model.name, name);
   }
 
   @Test
@@ -129,7 +121,17 @@ public class LongToDateTimeAdapterTest {
     // Assert
     assertNotNull(model.birthDate);
     assertEquals(model.birthDate.getTime(), date.getTime());
-    assertEquals(model.name, "Lorem");
+    assertEquals(model.name, name);
+  }
+
+  @Test(expectedExceptions = NumberFormatException.class)
+  public void readShouldThrowWhenWhenJsonValueStringIsNotLongAsString() {
+    // Arrange
+    String mixed = "2342sdf345";
+    String json = String.format("{\"birth_date\":\"%s\", \"name\":\"%s\"}", mixed, name);
+
+    // Act
+    gson.fromJson(json, LongToDateTimeAdapterModel.class);
   }
 
 

--- a/src/test/java/com/ibm/cloud/sdk/core/util/LongToDateTimeAdapterTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/LongToDateTimeAdapterTest.java
@@ -1,0 +1,47 @@
+package com.ibm.cloud.sdk.core.util;
+
+import java.util.Date;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class LongToDateTimeAdapterTest {
+  private Gson gson;
+
+  @Test
+  public void writeShouldSerializeDateNullToJsonNullValue() {
+    // Arrange
+    LongToDateTimeAdatpterModel model = new LongToDateTimeAdatpterModel();
+    model.birthDate = null;
+    model.name = "Lorem";
+
+    // Act
+    String serialized = gson.toJson(model);
+
+    // Assert
+    assertTrue(serialized.contains("\"name\":\"Lorem\""));
+    assertFalse(serialized.contains("birth_date"));
+  }
+
+  @BeforeMethod
+  public void beforeMethod() {
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    gsonBuilder.registerTypeAdapter(Date.class, new LongToDateTypeAdapter());
+    gson = gsonBuilder.create();
+  }
+
+  private class LongToDateTimeAdatpterModel {
+    @SerializedName("birth_date")
+    public Date birthDate;
+
+    @SerializedName("name")
+    public String name;
+
+  }
+}

--- a/src/test/java/com/ibm/cloud/sdk/core/util/LongToDateTimeAdapterTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/LongToDateTimeAdapterTest.java
@@ -9,25 +9,129 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 public class LongToDateTimeAdapterTest {
   private Gson gson;
+  private String name = "Lorem";
 
   @Test
-  public void writeShouldSerializeDateNullToJsonNullValue() {
+  public void writeShouldSerializeDateNullValueToJsonNullValue() {
     // Arrange
-    LongToDateTimeAdatpterModel model = new LongToDateTimeAdatpterModel();
+    LongToDateTimeAdapterModel model = new LongToDateTimeAdapterModel();
     model.birthDate = null;
-    model.name = "Lorem";
+    model.name = name;
 
     // Act
     String serialized = gson.toJson(model);
 
     // Assert
-    assertTrue(serialized.contains("\"name\":\"Lorem\""));
+    assertTrue(serialized.contains(String.format("\"name\":\"%s\"", name)));
     assertFalse(serialized.contains("birth_date"));
   }
+
+  @Test
+  public void writeShouldSerializeDateNowValueToJsonValue() {
+    // Arrange
+    Date date = new Date();
+    LongToDateTimeAdapterModel model = new LongToDateTimeAdapterModel();
+    model.birthDate = date;
+    model.name = name;
+
+    // Act
+    String serialized = gson.toJson(model);
+
+    // Assert
+    assertTrue(serialized.contains(String.format("\"name\":\"%s\"", name)));
+    assertTrue(serialized.contains(String.format("\"birth_date\":%d", date.getTime())));
+  }
+
+  @Test
+  public void writeShouldSerializeDateWithPriorUnixTimeStartValueToJsonValue() {
+    // Arrange
+    LongToDateTimeAdapterModel model = new LongToDateTimeAdapterModel();
+    model.birthDate = new Date(-31489139000L);
+    model.name = name;
+
+    // Act
+    String serialized = gson.toJson(model);
+
+    // Assert
+    assertTrue(serialized.contains(String.format("\"name\":\"%s\"", name)));
+    assertTrue(serialized.contains(String.format("\"birth_date\":%d", model.birthDate.getTime())));
+  }
+
+  @Test
+  public void readShouldDeserializeJsonNullValueToDateNull() {
+    // Arrange
+    String json = String.format("{\"birth_date\":null, \"name\":\"%s\"}", name);
+
+    // Act
+    LongToDateTimeAdapterModel model = gson.fromJson(json, LongToDateTimeAdapterModel.class);
+
+    // Assert
+    assertNull(model.birthDate);
+    assertEquals(model.name, name);
+  }
+
+  @Test(expectedExceptions = NumberFormatException.class)
+  public void readShouldThrowWhenDateJsonValueIsEmptyString() {
+    // Arrange
+    String json = String.format("{\"birth_date\":\"\", \"name\":\"%s\"}", name);
+
+    // Act
+    LongToDateTimeAdapterModel model = gson.fromJson(json, LongToDateTimeAdapterModel.class);
+
+    // Assert
+    assertNull(model.birthDate);
+    assertEquals(model.name, "Lorem");
+  }
+
+  @Test(expectedExceptions = NumberFormatException.class)
+  public void readShouldThrowWhenJsonDateValueIsSpaceString() {
+    // Arrange
+    String json = String.format("{\"birth_date\":\" \", \"name\":\"%s\"}", name);
+
+    // Act
+    LongToDateTimeAdapterModel model = gson.fromJson(json, LongToDateTimeAdapterModel.class);
+
+    // Assert
+    assertNull(model.birthDate);
+    assertEquals(model.name, "Lorem");
+  }
+
+  @Test
+  public void readShouldDeserializeWhenJsonValueIsNumber() {
+    // Arrange
+    Date date = new Date();
+    String json = String.format("{\"birth_date\":%d, \"name\":\"%s\"}", date.getTime(), name);
+
+    // Act
+    LongToDateTimeAdapterModel model = gson.fromJson(json, LongToDateTimeAdapterModel.class);
+
+    // Assert
+    assertNotNull(model.birthDate);
+    assertEquals(model.birthDate.getTime(), date.getTime());
+    assertEquals(model.name, "Lorem");
+  }
+
+  @Test
+  public void readShouldDeserializeWhenJsonValueIsStringButNumberInIt() {
+    // Arrange
+    Date date = new Date();
+    String json = String.format("{\"birth_date\":\"%d\", \"name\":\"%s\"}", date.getTime(), name);
+
+    // Act
+    LongToDateTimeAdapterModel model = gson.fromJson(json, LongToDateTimeAdapterModel.class);
+
+    // Assert
+    assertNotNull(model.birthDate);
+    assertEquals(model.birthDate.getTime(), date.getTime());
+    assertEquals(model.name, "Lorem");
+  }
+
 
   @BeforeMethod
   public void beforeMethod() {
@@ -36,7 +140,7 @@ public class LongToDateTimeAdapterTest {
     gson = gsonBuilder.create();
   }
 
-  private class LongToDateTimeAdatpterModel {
+  private class LongToDateTimeAdapterModel {
     @SerializedName("birth_date")
     public Date birthDate;
 


### PR DESCRIPTION
This Pr brings 100% coverage for the `LongToDateTypeAdapter`. This adapter is not used in the Gson setup the core provides by default, but part of the core and has to be covered by tests.

The overall coverage looks like below.


Note the following:

- I went a little bit further than 100% coverage and created a few extra tests simulating real world cases
- cases where deprecated constructors of Date class used, like `new Date(1990, 1, 1)` aren't covered
- there is a discrepancy of how the case is managed when empty string the value in the json string ( `{date:""}`, this adapter throws exception, but the `BooleanToStringTypeAdapter` handles it as `NULL` value. I provided a test covering this for documentation pusposes and created a ticket on our board about to check consistency across TypeAdapters around this case

<img width="1133" alt="Screenshot 2021-07-18 at 13 02 28" src="https://user-images.githubusercontent.com/5106373/126064733-6e2d552e-7941-4e41-814e-b6d1e42fd63a.png">