### PR TITLE
tests: improve test coverage responseconverterutils

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-07-12T17:52:36Z",
+  "generated_at": "2021-07-26T18:11:07Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/ResponseTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/ResponseTest.java
@@ -18,16 +18,14 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
+import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
 import com.ibm.cloud.sdk.core.http.Response;
@@ -42,13 +40,15 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 import com.ibm.cloud.sdk.core.test.BaseServiceUnitTest;
 import com.ibm.cloud.sdk.core.util.Clock;
 import com.ibm.cloud.sdk.core.util.ResponseConverterUtils;
-
 import io.reactivex.Single;
 import io.reactivex.functions.Consumer;
 import io.reactivex.schedulers.Schedulers;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 public class ResponseTest extends BaseServiceUnitTest {
   private class TestModel extends GenericModel {
@@ -56,6 +56,45 @@ public class ResponseTest extends BaseServiceUnitTest {
 
     String getCity() {
       return city;
+    }
+  }
+
+  public class GenericObjectModel extends GenericModel {
+    @SerializedName("name")
+    String name;
+
+    @SerializedName("address")
+    String address;
+
+    @SerializedName("age")
+    Integer age;
+
+    public String getName() {
+      return name;
+    }
+
+    public String getAddress() {
+      return address;
+    }
+
+    public Integer getAge() {
+      return age;
+    }
+  }
+
+  public class PassportModel {
+    @SerializedName("serial")
+    private String serial;
+
+    @SerializedName("issuer")
+    private String issuer;
+
+    public String getSerial() {
+      return serial;
+    }
+
+    public String getIssuer() {
+      return issuer;
     }
   }
 
@@ -75,7 +114,8 @@ public class ResponseTest extends BaseServiceUnitTest {
     ServiceCall<TestModel> getTestModelGenericType() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<TestModel> responseConverter =
-          ResponseConverterUtils.getValue(new TypeToken<TestModel>(){}.getType());
+          ResponseConverterUtils.getValue(new TypeToken<TestModel>() {
+          }.getType());
       return createServiceCall(builder.build(), responseConverter);
     }
 
@@ -84,39 +124,62 @@ public class ResponseTest extends BaseServiceUnitTest {
       return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
     }
 
-    ServiceCall<String> getString() {
+    ServiceCall<String> getStringTypeGenericType() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<String> responseConverter =
-          ResponseConverterUtils.getValue(new TypeToken<String>(){}.getType());
+          ResponseConverterUtils.getValue(new TypeToken<String>() {
+          }.getType());
       return createServiceCall(builder.build(), responseConverter);
     }
 
-    ServiceCall<List<String>> getListString() {
+    ServiceCall<List<String>> getListStringTypeGenericType() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<List<String>> responseConverter =
-          ResponseConverterUtils.getValue(new TypeToken<List<String>>(){}.getType());
+          ResponseConverterUtils.getValue(new TypeToken<List<String>>() {
+          }.getType());
       return createServiceCall(builder.build(), responseConverter);
     }
 
-    ServiceCall<Long> getLong() {
+    ServiceCall<Long> getLongTypeGenericType() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<Long> responseConverter =
-          ResponseConverterUtils.getValue(new TypeToken<Long>(){}.getType());
+          ResponseConverterUtils.getValue(new TypeToken<Long>() {
+          }.getType());
       return createServiceCall(builder.build(), responseConverter);
     }
 
-    ServiceCall<List<Long>> getListLong() {
+    ServiceCall<List<Long>> getListLongTypeGenericType() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<List<Long>> responseConverter =
-          ResponseConverterUtils.getValue(new TypeToken<List<Long>>(){}.getType());
+          ResponseConverterUtils.getValue(new TypeToken<List<Long>>() {
+          }.getType());
       return createServiceCall(builder.build(), responseConverter);
     }
 
-    ServiceCall<List<TestModel>> getListTestModel() {
+    ServiceCall<List<TestModel>> getListTestModelTypeGenericType() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<List<TestModel>> responseConverter =
-          ResponseConverterUtils.getValue(new TypeToken<List<TestModel>>(){}.getType());
+          ResponseConverterUtils.getValue(new TypeToken<List<TestModel>>() {
+          }.getType());
       return createServiceCall(builder.build(), responseConverter);
+    }
+
+    ServiceCall<String> getStringTypeGenericObject(final String propertyName) {
+      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
+      return createServiceCall(builder.build(),
+          ResponseConverterUtils.getGenericObject(String.class, propertyName));
+    }
+
+    ServiceCall<PassportModel> getPassportModelGenericObject(
+        final String propertyName) {
+      RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
+      return createServiceCall(builder.build(),
+          ResponseConverterUtils.getGenericObject(PassportModel.class, propertyName));
+    }
+
+    ServiceCall<GenericObjectModel> getObjectExtendsGeneric(final TestModel type) {
+      RequestBuilder builder = RequestBuilder.get(HttpUrl.get(getServiceUrl() + "/v1/test"));
+      return createServiceCall(builder.build(), ResponseConverterUtils.getValue((Type) type));
     }
   }
 
@@ -219,7 +282,7 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test
-  public void testShouldThrowWhenInvalidJsonIsEnqueued() throws InterruptedException{
+  public void testShouldThrowWhenInvalidJsonIsEnqueued() throws InterruptedException {
     // Arrange
     String responseBody = "{\"city\": \"Colum";
     server.enqueue(new MockResponse().setBody(responseBody));
@@ -330,7 +393,7 @@ public class ResponseTest extends BaseServiceUnitTest {
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<String> response = service.getString().execute();
+    Response<String> response = service.getStringTypeGenericType().execute();
 
     // Assert
     String result = response.getResult();
@@ -346,7 +409,7 @@ public class ResponseTest extends BaseServiceUnitTest {
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<List<String>> response = service.getListString().execute();
+    Response<List<String>> response = service.getListStringTypeGenericType().execute();
 
     // Arrange
     List<String> result = response.getResult();
@@ -364,7 +427,7 @@ public class ResponseTest extends BaseServiceUnitTest {
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<Long> response = service.getLong().execute();
+    Response<Long> response = service.getLongTypeGenericType().execute();
 
     // Assert
     Long result = response.getResult();
@@ -380,7 +443,7 @@ public class ResponseTest extends BaseServiceUnitTest {
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<List<Long>> response = service.getListLong().execute();
+    Response<List<Long>> response = service.getListLongTypeGenericType().execute();
 
     // Assert
     List<Long> result = response.getResult();
@@ -406,7 +469,7 @@ public class ResponseTest extends BaseServiceUnitTest {
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<List<TestModel>> response = service.getListTestModel().execute();
+    Response<List<TestModel>> response = service.getListTestModelTypeGenericType().execute();
 
     // Assert
     List<TestModel> result = response.getResult();
@@ -427,7 +490,7 @@ public class ResponseTest extends BaseServiceUnitTest {
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<List<TestModel>> response = service.getListTestModel().execute();
+    Response<List<TestModel>> response = service.getListTestModelTypeGenericType().execute();
 
     // Assert
     List<TestModel> list = response.getResult();
@@ -441,7 +504,7 @@ public class ResponseTest extends BaseServiceUnitTest {
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<List<TestModel>> response = service.getListTestModel().execute();
+    Response<List<TestModel>> response = service.getListTestModelTypeGenericType().execute();
 
     // Assert
     List<TestModel> list = response.getResult();
@@ -517,4 +580,113 @@ public class ResponseTest extends BaseServiceUnitTest {
     Thread.sleep(500);
     assertTrue(callWasCanceled[0]);
   }
+
+  @DataProvider(name = "stringResponseBodyMemberIsNullOrEmptyOrWhitespace")
+  public static Object[][] stringResponseBodyMemberIsNullOrEmptyOrWhitespaceDataProvider() {
+    return new Object[][]{
+        {"null"},
+        {""},
+        {" "}
+    };
+  }
+
+  @Test(dataProvider = "stringResponseBodyMemberIsNullOrEmptyOrWhitespace")
+  public void testGenericObjectStringShouldReturnNullValueWhenStringValueOfResponseBodyMemberIsEmptyOrNullValue(
+      String expectedValue
+  ) {
+    // Arrange
+    String responseBody = String.format("{\"name\":\"%s\"}", expectedValue);
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    Response<String> response = service.getStringTypeGenericObject("name").execute();
+
+    // Assert
+    assertNotNull(response);
+    assertNotNull(response.getResult());
+    assertTrue(response.getResult().equals(expectedValue));
+  }
+
+  @Test
+  public void testGenericObjectStringShouldReturnStringValueOfResponseBodyMember2() {
+    // Arrange
+    String expectedNameValue = "lorem";
+    String responseBody = String.format("{\"name\":\"%s\"}", expectedNameValue);
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    Response<String> response = service.getStringTypeGenericObject("name").execute();
+
+    // Assert
+    assertNotNull(response);
+    assertNotNull(response.getResult());
+    assertEquals(response.getResult(), expectedNameValue);
+  }
+
+  @Test
+  public void testGenericObjectShouldReturnNullObjectWhenResponseBodyMemberIsNullValue() {
+    // Arrange
+    String responseBody = "{\"name\"=\"Lorem\", \"age\":\"45\", \"passport\":null}";
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    Response<PassportModel> response = service.getPassportModelGenericObject("passport").execute();
+
+    // Assert
+    assertNotNull(response);
+    assertNull(response.getResult());
+  }
+
+  @Test
+  public void testGenericObjectShouldReturnObjectWhenResponseBodyMemberIsEmptyObject() {
+    // Arrange
+    String responseBody = "{\"name\"=\"Lorem\", \"age\":\"45\", \"passport\":{}}";
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    Response<PassportModel> response = service.getPassportModelGenericObject("passport").execute();
+
+    // Assert
+    assertNotNull(response);
+    assertNotNull(response.getResult());
+    assertNull(response.getResult().getIssuer());
+    assertNull(response.getResult().getSerial());
+  }
+
+  @Test
+  public void testGenericObjectShouldReturnGivenTypeOfObjectOfResponseBodyMember() {
+    // Arrange
+    String expectedPassportIssuer = "Office";
+    String expectedPassportSerialNumber = "AB12345";
+    String passportModel = String.format("{\"issuer\":\"%s\", \"serial\":\"%s\"}",
+        expectedPassportIssuer,
+        expectedPassportSerialNumber);
+    String responseBody = String.format("{\"name\"=\"Lorem\", \"age\":\"45\", \"passport\":%s}", passportModel);
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    Response<PassportModel> response = service.getPassportModelGenericObject("passport").execute();
+
+    // Assert
+    assertNotNull(response);
+    assertNotNull(response.getResult());
+    assertEquals(response.getResult().getSerial(), expectedPassportSerialNumber);
+    assertEquals(response.getResult().getIssuer(), expectedPassportIssuer);
+  }
+
+  // @Test
+  // public void test() {
+  //   // Arrange
+  //   String expectedValue = "Columbus";
+  //   String responseBody = String.format("{\"city\": \"%s\"}", expectedValue);
+  //   server.enqueue(new MockResponse().setBody(responseBody));
+  //
+  //   // Act
+  //   Response<TestModel> response = service.getObjectExtendsGeneric(TestModel.class).execute();
+  //
+  //   // Assert
+  //   assertNotNull(response.getResult());
+  //   assertEquals(expectedValue, response.getResult().getCity());
+  //   assertNotNull(response.getHeaders());
+  // }
 }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/ResponseTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/ResponseTest.java
@@ -18,7 +18,6 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -106,12 +105,12 @@ public class ResponseTest extends BaseServiceUnitTest {
       super(SERVICE_NAME, auth);
     }
 
-    ServiceCall<TestModel> getTestModelPOJO() {
+    ServiceCall<TestModel> getTestModelByResponseConverterUtilsGetObject() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       return createServiceCall(builder.build(), ResponseConverterUtils.getObject(TestModel.class));
     }
 
-    ServiceCall<TestModel> getTestModelGenericType() {
+    ServiceCall<TestModel> getTestModelByResponseConverterUtilsGetValue() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<TestModel> responseConverter =
           ResponseConverterUtils.getValue(new TypeToken<TestModel>() {
@@ -124,7 +123,7 @@ public class ResponseTest extends BaseServiceUnitTest {
       return createServiceCall(builder.build(), ResponseConverterUtils.getVoid());
     }
 
-    ServiceCall<String> getStringTypeGenericType() {
+    ServiceCall<String> getStringByResponseConverterUtilsGetValue() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<String> responseConverter =
           ResponseConverterUtils.getValue(new TypeToken<String>() {
@@ -132,7 +131,7 @@ public class ResponseTest extends BaseServiceUnitTest {
       return createServiceCall(builder.build(), responseConverter);
     }
 
-    ServiceCall<List<String>> getListStringTypeGenericType() {
+    ServiceCall<List<String>> getListOfStringsByResponseConverterUtilsGetValue() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<List<String>> responseConverter =
           ResponseConverterUtils.getValue(new TypeToken<List<String>>() {
@@ -140,7 +139,7 @@ public class ResponseTest extends BaseServiceUnitTest {
       return createServiceCall(builder.build(), responseConverter);
     }
 
-    ServiceCall<Long> getLongTypeGenericType() {
+    ServiceCall<Long> getLongByResponseConverterUtilsGetValue() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<Long> responseConverter =
           ResponseConverterUtils.getValue(new TypeToken<Long>() {
@@ -148,7 +147,7 @@ public class ResponseTest extends BaseServiceUnitTest {
       return createServiceCall(builder.build(), responseConverter);
     }
 
-    ServiceCall<List<Long>> getListLongTypeGenericType() {
+    ServiceCall<List<Long>> getListLongValuesByResponseConverterUtilsGetValue() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<List<Long>> responseConverter =
           ResponseConverterUtils.getValue(new TypeToken<List<Long>>() {
@@ -156,7 +155,7 @@ public class ResponseTest extends BaseServiceUnitTest {
       return createServiceCall(builder.build(), responseConverter);
     }
 
-    ServiceCall<List<TestModel>> getListTestModelTypeGenericType() {
+    ServiceCall<List<TestModel>> getListOfTestModelsByResponseConverterUtilsGetValue() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<List<TestModel>> responseConverter =
           ResponseConverterUtils.getValue(new TypeToken<List<TestModel>>() {
@@ -164,23 +163,24 @@ public class ResponseTest extends BaseServiceUnitTest {
       return createServiceCall(builder.build(), responseConverter);
     }
 
-    ServiceCall<String> getStringTypeGenericObject(final String propertyName) {
+    ServiceCall<String> getStringByResponseConverterUtilsGenericObject(final String propertyName) {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       return createServiceCall(builder.build(),
           ResponseConverterUtils.getGenericObject(String.class, propertyName));
     }
 
-    ServiceCall<PassportModel> getPassportModelGenericObject(
+    ServiceCall<PassportModel> getPassportModelByResponseConverterUtilsGenericObject(
         final String propertyName) {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       return createServiceCall(builder.build(),
           ResponseConverterUtils.getGenericObject(PassportModel.class, propertyName));
     }
 
-    ServiceCall<GenericObjectModel> getObjectExtendsGeneric(final TestModel type) {
+    ServiceCall<String> getStringRepresentationOfResponseBodyByResponseConverterUtilsGetString() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.get(getServiceUrl() + "/v1/test"));
-      return createServiceCall(builder.build(), ResponseConverterUtils.getValue((Type) type));
+      return createServiceCall(builder.build(), ResponseConverterUtils.getString());
     }
+
   }
 
   private TestService service;
@@ -194,14 +194,14 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test
-  public void testAllFieldsShouldBePopulatedWhenTheResponseIsPOJO() {
+  public void testGetObjectShouldReturnAnObjectAllFieldsPopulatedWhenResponseBodyIsAPOJO() {
     // Arrange
     String expectedValue = "Columbus";
     String responseBody = String.format("{\"city\": \"%s\"}", expectedValue);
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<TestModel> response = service.getTestModelPOJO().execute();
+    Response<TestModel> response = service.getTestModelByResponseConverterUtilsGetObject().execute();
 
     // Assert
     assertNotNull(response.getResult());
@@ -210,26 +210,26 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test
-  public void testNullResultShouldReturnWhenNoResponse() {
+  public void testGetObjectShouldReturnNullWhenResponseBodyIsEmpty() {
     // Arrange
     String responseBody = "";
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<TestModel> response = service.getTestModelPOJO().execute();
+    Response<TestModel> response = service.getTestModelByResponseConverterUtilsGetObject().execute();
 
     // Assert
     assertNull(response.getResult());
   }
 
   @Test
-  public void testShouldReturnEmptyModelWhenResponseIsAnEmptyObject() {
+  public void testGetObjectShouldReturnEmptyModelWhenResponseBodyIsEmptyObject() {
     // Arrange
     String responseBody = "{}";
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<TestModel> response = service.getTestModelPOJO().execute();
+    Response<TestModel> response = service.getTestModelByResponseConverterUtilsGetObject().execute();
 
     // Assert
     TestModel obj = response.getResult();
@@ -238,17 +238,17 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test(expectedExceptions = InvalidServiceResponseException.class)
-  public void testShouldThrowWhenJsonResponseIsInvalidJson() {
+  public void testGetObjectShouldThrowWhenResponseBodyIsInvalidJson() {
     // Arrange
     String responseBody = "{\"city\": \"Colum";
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    service.getTestModelPOJO().execute();
+    service.getTestModelByResponseConverterUtilsGetObject().execute();
   }
 
   @Test
-  public void testShouldPopulateAllFieldsWhenCallingEnqueue() throws InterruptedException {
+  public void testGetObjectShouldPopulateAllFieldsWhenCallingEnqueue() throws InterruptedException {
     // Arrange
     String expectedValueFromResultModel = "Columbus";
     String responseBody = String.format("{\"city\": \"%s\"}", expectedValueFromResultModel);
@@ -257,7 +257,7 @@ public class ResponseTest extends BaseServiceUnitTest {
     final Map<String, Object> results = new HashMap<>();
 
     // Act
-    service.getTestModelPOJO().enqueue(new ServiceCallback<TestModel>() {
+    service.getTestModelByResponseConverterUtilsGetObject().enqueue(new ServiceCallback<TestModel>() {
       @Override
       public void onResponse(Response<TestModel> response) {
         results.put("method", "onResponse");
@@ -282,7 +282,7 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test
-  public void testShouldThrowWhenInvalidJsonIsEnqueued() throws InterruptedException {
+  public void testGetObjectShouldThrowWhenInvalidJsonIsEnqueued() throws InterruptedException {
     // Arrange
     String responseBody = "{\"city\": \"Colum";
     server.enqueue(new MockResponse().setBody(responseBody));
@@ -290,7 +290,7 @@ public class ResponseTest extends BaseServiceUnitTest {
     final Map<String, Object> results = new HashMap<>();
 
     // Act
-    service.getTestModelPOJO().enqueue(new ServiceCallback<TestModel>() {
+    service.getTestModelByResponseConverterUtilsGetObject().enqueue(new ServiceCallback<TestModel>() {
       @Override
       public void onResponse(Response<TestModel> response) {
         results.put("method", "onResponse");
@@ -314,7 +314,7 @@ public class ResponseTest extends BaseServiceUnitTest {
 
 
   @Test
-  public void testReactiveRequestShouldCompleteCorrectly() throws InterruptedException {
+  public void testGetObjectReactiveRequestShouldCompleteCorrectly() throws InterruptedException {
     // Arrange
     String expectedValue = "Columbus";
     String responseBody = String.format("{\"city\": \"%s\"}", expectedValue);
@@ -323,7 +323,8 @@ public class ResponseTest extends BaseServiceUnitTest {
     final Map<String, Object> results = new HashMap<>();
 
     // Act
-    Single<Response<TestModel>> observableRequest = service.getTestModelPOJO().reactiveRequest();
+    Single<Response<TestModel>> observableRequest = service.getTestModelByResponseConverterUtilsGetObject()
+        .reactiveRequest();
 
     // Assert
     observableRequest
@@ -370,14 +371,14 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test
-  public void testAllFieldsShouldBePopulatedWhenResultIsGenericType() {
+  public void testGetValueShouldReturnObjectWithAllFieldsPopulatedWhenResponseBodyIsPOJO() {
     // Arrange
     String expectedValue = "Columbus";
     String responseBody = String.format("{\"city\": \"%s\"}", expectedValue);
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<TestModel> response = service.getTestModelGenericType().execute();
+    Response<TestModel> response = service.getTestModelByResponseConverterUtilsGetValue().execute();
 
     // Assert
     assertNotNull(response.getResult());
@@ -386,14 +387,53 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test
-  public void testShouldReturnStringDeserializedCorrectly() {
+  public void testGetValueShouldReturnNullWhenResponseBodyIsEmpty() {
+    // Arrange
+    String responseBody = "";
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    Response<TestModel> response = service.getTestModelByResponseConverterUtilsGetValue().execute();
+
+    // Assert
+    assertNotNull(response);
+    assertNull(response.getResult());
+  }
+
+  @Test
+  public void testGetValueShouldReturnEmptyModelWhenResponseBodyIsEmpty() {
+    // Arrange
+    String responseBody = "{}";
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    Response<TestModel> response = service.getTestModelByResponseConverterUtilsGetValue().execute();
+
+    // Assert
+    assertNotNull(response);
+    assertNotNull(response.getResult());
+    assertNull(response.getResult().getCity());
+  }
+
+  @Test(expectedExceptions = InvalidServiceResponseException.class)
+  public void testGetValueShouldThrowWhenResponseBodyIsInvalidJson() {
+    // Arrange
+    String responseBody = "{\"city\": \"Colum";
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    service.getTestModelByResponseConverterUtilsGetValue().execute();
+  }
+
+  @Test
+  public void testGetValueShouldReturnStringDeserializedCorrectly() {
     // Arrange
     String expectedResult = "string response";
     String responseBody = String.format("\"%s\"", expectedResult);
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<String> response = service.getStringTypeGenericType().execute();
+    Response<String> response = service.getStringByResponseConverterUtilsGetValue().execute();
 
     // Assert
     String result = response.getResult();
@@ -402,14 +442,36 @@ public class ResponseTest extends BaseServiceUnitTest {
     assertNotNull(response.getHeaders());
   }
 
+  @DataProvider(name = "testGetValueShouldReturnString")
+  public static Object[][] testGetValueShouldReturnStringDataProvider() {
+    return new Object[][]{
+        {""},
+        {" "},
+        };
+  }
+
+  @Test(dataProvider = "testGetValueShouldReturnString")
+  public void testGetValueShouldReturnNullWhenStringResponseIsEmptyOrWhitespace(String responseBody) {
+    // Arrange
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    Response<String> response = service.getStringByResponseConverterUtilsGetValue().execute();
+
+    // Assert
+    String result = response.getResult();
+    assertNull(result);
+    assertNotNull(response.getHeaders());
+  }
+
   @Test
-  public void testShouldReturnListOfStringsDeserializedCorrectly() {
+  public void testGetValueShouldReturnListOfStringsDeserializedCorrectly() {
     // Arrange
     String responseBody = "[\"string1\",\"string2\",\"string3\"]";
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<List<String>> response = service.getListStringTypeGenericType().execute();
+    Response<List<String>> response = service.getListOfStringsByResponseConverterUtilsGetValue().execute();
 
     // Arrange
     List<String> result = response.getResult();
@@ -420,14 +482,65 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test
-  public void testShouldReturnLongDeserializedCorrectly() {
+  public void testGetValueShouldReturnListOfStringsDeserializedCorrectlyWhenAnItemIsNullValue() {
+    // Arrange
+    String responseBody = "[\"string1\",null ,\"string3\"]";
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    Response<List<String>> response = service.getListOfStringsByResponseConverterUtilsGetValue().execute();
+
+    // Arrange
+    List<String> result = response.getResult();
+    assertNotNull(result);
+    assertEquals(result.size(), 3);
+    assertEquals(Arrays.asList("string1", null, "string3"), result);
+    assertNotNull(response.getHeaders());
+  }
+
+  @Test
+  public void testGetValueShouldReturnListOfStringsDeserializedCorrectlyWhenAnItemIsEmptyString() {
+    // Arrange
+    String responseBody = "[\"string1\",\"\" ,\"string3\"]";
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    Response<List<String>> response = service.getListOfStringsByResponseConverterUtilsGetValue().execute();
+
+    // Arrange
+    List<String> result = response.getResult();
+    assertNotNull(result);
+    assertEquals(result.size(), 3);
+    assertEquals(Arrays.asList("string1", "", "string3"), result);
+    assertNotNull(response.getHeaders());
+  }
+
+  @Test
+  public void testGetValueShouldReturnListOfStringsDeserializedCorrectlyWhenAnItemIsWhitespace() {
+    // Arrange
+    String responseBody = "[\"string1\",\" \" ,\"string3\"]";
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    Response<List<String>> response = service.getListOfStringsByResponseConverterUtilsGetValue().execute();
+
+    // Arrange
+    List<String> result = response.getResult();
+    assertNotNull(result);
+    assertEquals(result.size(), 3);
+    assertEquals(Arrays.asList("string1", " ", "string3"), result);
+    assertNotNull(response.getHeaders());
+  }
+
+  @Test
+  public void testGetValueShouldReturnLongDeserializedCorrectly() {
     // Arrange
     String responseBody = "443374";
     Long expectedResult = Long.parseLong(responseBody);
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<Long> response = service.getLongTypeGenericType().execute();
+    Response<Long> response = service.getLongByResponseConverterUtilsGetValue().execute();
 
     // Assert
     Long result = response.getResult();
@@ -436,14 +549,24 @@ public class ResponseTest extends BaseServiceUnitTest {
     assertNotNull(response.getHeaders());
   }
 
+  @Test(expectedExceptions = {InvalidServiceResponseException.class})
+  public void testGetValueShouldThrowWhenLongValueIsInvalid() {
+    // Arrange
+    String responseBody = "443f374";
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    service.getLongByResponseConverterUtilsGetValue().execute();
+  }
+
   @Test
-  public void testShouldReturnListOfLongsDeserializedCorrectly() {
+  public void testGetValueShouldReturnListOfLongsDeserializedCorrectly() {
     // Arrange
     String responseBody = "[44,33,74]";
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<List<Long>> response = service.getListLongTypeGenericType().execute();
+    Response<List<Long>> response = service.getListLongValuesByResponseConverterUtilsGetValue().execute();
 
     // Assert
     List<Long> result = response.getResult();
@@ -459,17 +582,24 @@ public class ResponseTest extends BaseServiceUnitTest {
     assertNotNull(response.getHeaders());
   }
 
-  /**
-   * Test that list of TestModels response can be deserialized correctly.
-   */
+  @Test(expectedExceptions = {InvalidServiceResponseException.class})
+  public void testGetValueShouldThrowWhenInvalidLongIsInTheList() {
+    // Arrange
+    String responseBody = "[44,3f3,74]";
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    service.getListLongValuesByResponseConverterUtilsGetValue().execute();
+  }
+
   @Test
-  public void testShouldReturnListOfObjectDeserializedCorrectly() {
+  public void testGetValueShouldReturnListOfObjectsDeserializedCorrectly() {
     // Arrange
     String responseBody = "[{\"city\":\"Austin\"},{\"city\":\"Georgetown\"},{\"city\":\"Cedar Park\"}]";
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<List<TestModel>> response = service.getListTestModelTypeGenericType().execute();
+    Response<List<TestModel>> response = service.getListOfTestModelsByResponseConverterUtilsGetValue().execute();
 
     // Assert
     List<TestModel> result = response.getResult();
@@ -484,13 +614,59 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test
-  public void testShouldReturnNullListWhenResponseBodyIsMissing() {
+  public void testGetValueShouldReturnListOfObjectsDeserializedCorrectlyWhenOneFromTheItemIsNull() {
+    // Arrange
+    String responseBody = "[{\"city\":\"Austin\"},null ,{\"city\":\"Cedar Park\"}]";
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    Response<List<TestModel>> response = service.getListOfTestModelsByResponseConverterUtilsGetValue().execute();
+
+    // Assert
+    List<TestModel> result = response.getResult();
+    assertNotNull(result);
+    assertEquals(result.size(), 3);
+    List<String> actualCities = new ArrayList<>();
+    for (TestModel obj : result) {
+      if (obj != null && obj.getCity() != null) {
+        actualCities.add(obj.getCity());
+      }
+    }
+    assertEquals(Arrays.asList("Austin", "Cedar Park"), actualCities);
+    assertNotNull(response.getHeaders());
+  }
+
+  @Test
+  public void testGetValueShouldReturnListOfObjectsDeserializedCorrectlyWhenFromTheItemsIsEmptyObject() {
+    // Arrange
+    String responseBody = "[{\"city\":\"Austin\"},{} ,{\"city\":\"Cedar Park\"}]";
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    Response<List<TestModel>> response = service.getListOfTestModelsByResponseConverterUtilsGetValue().execute();
+
+    // Assert
+    List<TestModel> result = response.getResult();
+    assertNotNull(result);
+    assertEquals(result.size(), 3);
+    List<String> actualCities = new ArrayList<>();
+    for (TestModel obj : result) {
+      if (obj != null && obj.getCity() != null) {
+        actualCities.add(obj.getCity());
+      }
+    }
+    assertEquals(Arrays.asList("Austin", "Cedar Park"), actualCities);
+    assertNotNull(response.getHeaders());
+  }
+
+  @Test
+  public void testGetValueShouldReturnNullListWhenResponseBodyIsMissing() {
     // Arrange
     String responseBody = "";
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<List<TestModel>> response = service.getListTestModelTypeGenericType().execute();
+    Response<List<TestModel>> response = service.getListOfTestModelsByResponseConverterUtilsGetValue().execute();
 
     // Assert
     List<TestModel> list = response.getResult();
@@ -498,13 +674,13 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test
-  public void testShouldReturnEmptyListWhenResponseBodyIsAnEmptyList() {
+  public void testGetValueShouldReturnEmptyListWhenResponseBodyIsAnEmptyList() {
     // Arrange
     String responseBody = "[]";
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<List<TestModel>> response = service.getListTestModelTypeGenericType().execute();
+    Response<List<TestModel>> response = service.getListOfTestModelsByResponseConverterUtilsGetValue().execute();
 
     // Assert
     List<TestModel> list = response.getResult();
@@ -513,7 +689,7 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test
-  public void testShouldReturnTheExpectedResponseCode() {
+  public void testHeadMethodShouldReturnTheExpectedResponseCode() {
     // Arrange
     server.enqueue(new MockResponse().setResponseCode(204));
 
@@ -525,7 +701,7 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test
-  public void testShouldBeAbleToRetrieveStatusLineFromResponseMessage() {
+  public void testHeadMethodShouldBeAbleToRetrieveStatusLineFromResponseMessage() {
     // Arrange
     server.enqueue(new MockResponse().setStatus("HTTP/1.1 204 No Content"));
 
@@ -537,7 +713,7 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test
-  public void testShouldBeAbleToCancelRequestCall() throws InterruptedException {
+  public void testGetObjectShouldBeAbleToCancelRequestCall() throws InterruptedException {
     // Arrange
     String responseBody = "{\"city\": \"Columbus\"}";
     server.enqueue(new MockResponse().setBody(responseBody).setBodyDelay(5000, TimeUnit.MILLISECONDS));
@@ -547,7 +723,7 @@ public class ResponseTest extends BaseServiceUnitTest {
     final boolean[] hasCallCompleted = {false};
     final boolean[] callWasCanceled = {false};
 
-    ServiceCall<TestModel> testCall = service.getTestModelPOJO();
+    ServiceCall<TestModel> testCall = service.getTestModelByResponseConverterUtilsGetObject();
     long startTime = Clock.getCurrentTimeInMillis();
     testCall.enqueue(new ServiceCallback<TestModel>() {
       @Override
@@ -591,7 +767,7 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test(dataProvider = "stringResponseBodyMemberIsNullOrEmptyOrWhitespace")
-  public void testGenericObjectStringShouldReturnNullValueWhenStringValueOfResponseBodyMemberIsEmptyOrNullValue(
+  public void testGenericObjectStringShouldReturnNullValueWhenResponseBodyStringValueIsEmptyOrNullValue(
       String expectedValue
   ) {
     // Arrange
@@ -599,7 +775,7 @@ public class ResponseTest extends BaseServiceUnitTest {
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<String> response = service.getStringTypeGenericObject("name").execute();
+    Response<String> response = service.getStringByResponseConverterUtilsGenericObject("name").execute();
 
     // Assert
     assertNotNull(response);
@@ -608,14 +784,14 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test
-  public void testGenericObjectStringShouldReturnStringValueOfResponseBodyMember2() {
+  public void testGenericObjectStringShouldReturnStringValue() {
     // Arrange
     String expectedNameValue = "lorem";
     String responseBody = String.format("{\"name\":\"%s\"}", expectedNameValue);
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<String> response = service.getStringTypeGenericObject("name").execute();
+    Response<String> response = service.getStringByResponseConverterUtilsGenericObject("name").execute();
 
     // Assert
     assertNotNull(response);
@@ -630,7 +806,8 @@ public class ResponseTest extends BaseServiceUnitTest {
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<PassportModel> response = service.getPassportModelGenericObject("passport").execute();
+    Response<PassportModel> response = service.getPassportModelByResponseConverterUtilsGenericObject("passport")
+        .execute();
 
     // Assert
     assertNotNull(response);
@@ -638,13 +815,14 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test
-  public void testGenericObjectShouldReturnObjectWhenResponseBodyMemberIsEmptyObject() {
+  public void testGenericObjectShouldReturnEmptyDefinedTypeWhenResponseBodyMemberIsEmptyObject() {
     // Arrange
     String responseBody = "{\"name\"=\"Lorem\", \"age\":\"45\", \"passport\":{}}";
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<PassportModel> response = service.getPassportModelGenericObject("passport").execute();
+    Response<PassportModel> response = service.getPassportModelByResponseConverterUtilsGenericObject("passport")
+        .execute();
 
     // Assert
     assertNotNull(response);
@@ -654,7 +832,7 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   @Test
-  public void testGenericObjectShouldReturnGivenTypeOfObjectOfResponseBodyMember() {
+  public void testGenericObjectShouldReturnDefinedType() {
     // Arrange
     String expectedPassportIssuer = "Office";
     String expectedPassportSerialNumber = "AB12345";
@@ -665,7 +843,8 @@ public class ResponseTest extends BaseServiceUnitTest {
     server.enqueue(new MockResponse().setBody(responseBody));
 
     // Act
-    Response<PassportModel> response = service.getPassportModelGenericObject("passport").execute();
+    Response<PassportModel> response = service.getPassportModelByResponseConverterUtilsGenericObject("passport")
+        .execute();
 
     // Assert
     assertNotNull(response);
@@ -674,19 +853,43 @@ public class ResponseTest extends BaseServiceUnitTest {
     assertEquals(response.getResult().getIssuer(), expectedPassportIssuer);
   }
 
-  // @Test
-  // public void test() {
-  //   // Arrange
-  //   String expectedValue = "Columbus";
-  //   String responseBody = String.format("{\"city\": \"%s\"}", expectedValue);
-  //   server.enqueue(new MockResponse().setBody(responseBody));
-  //
-  //   // Act
-  //   Response<TestModel> response = service.getObjectExtendsGeneric(TestModel.class).execute();
-  //
-  //   // Assert
-  //   assertNotNull(response.getResult());
-  //   assertEquals(expectedValue, response.getResult().getCity());
-  //   assertNotNull(response.getHeaders());
-  // }
+  @Test
+  public void testGetResponseBodyAsStringShouldReturnStringRepresentationOfResponseBody() {
+    // Arrange
+    String responseBody = "{\"name\":\"Lorem\", \"age\":\"45\"}";
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    Response<String> response = service.getStringRepresentationOfResponseBodyByResponseConverterUtilsGetString()
+        .execute();
+
+    // Assert
+    assertNotNull(response);
+    assertNotNull(response.getResult());
+    assertEquals(response.getResult(), responseBody);
+  }
+
+  @DataProvider(name = "getResponseBodyStringRepresentation")
+  public static Object[][] getResponseBodyStringRepresentationDataProvider() {
+    return new Object[][]{
+        {""},
+        {" "}
+    };
+  }
+
+  @Test(dataProvider = "getResponseBodyStringRepresentation")
+  public void testGetResponseBodyAsStringShouldReturnNullWhenResponseBodyIsEmptyOrWhitespace(String responseBody) {
+    // Arrange
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    Response<String> response = service.getStringRepresentationOfResponseBodyByResponseConverterUtilsGetString()
+        .execute();
+
+    // Assert
+    assertNotNull(response);
+    assertNotNull(response.getResult());
+    assertEquals(response.getResult(), responseBody);
+  }
+
 }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/ResponseTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/ResponseTest.java
@@ -67,12 +67,12 @@ public class ResponseTest extends BaseServiceUnitTest {
       super(SERVICE_NAME, auth);
     }
 
-    ServiceCall<TestModel> getTestModel() {
+    ServiceCall<TestModel> getTestModelPOJO() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       return createServiceCall(builder.build(), ResponseConverterUtils.getObject(TestModel.class));
     }
 
-    ServiceCall<TestModel> getTestModel2() {
+    ServiceCall<TestModel> getTestModelGenericType() {
       RequestBuilder builder = RequestBuilder.get(HttpUrl.parse(getServiceUrl() + "/v1/test"));
       ResponseConverter<TestModel> responseConverter =
           ResponseConverterUtils.getValue(new TypeToken<TestModel>(){}.getType());
@@ -121,23 +121,7 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
   private TestService service;
-  private String testResponseValue = "Columbus";
-  private String testResponseBody1 = "{\"city\": \"Columbus\"}";
-  private String testResponseBody2 = "[\"string1\",\"string2\",\"string3\"]";
-  private String testResponseBody3 = "[44,33,74]";
-  private String testResponseBody4 = "[{\"city\":\"Austin\"},{\"city\":\"Georgetown\"},{\"city\":\"Cedar Park\"}]";
-  private String testResponseBody5 = "\"string response\"";
-  private String testResponseBody6 = "443374";
-  private String testResponseBodyError1 = "{\"city\": \"Colum";
-  private String testResponseBodyMissing = "";
-  private String testResponseBodyEmptyObject = "{}";
-  private String testResponseBodyEmptyList = "[]";
 
-  /*
-   * (non-Javadoc)
-   *
-   * @see com.ibm.cloud.sdk.core.test.WatsonServiceTest#setUp()
-   */
   @Override
   @BeforeMethod
   public void setUp() throws Exception {
@@ -146,64 +130,71 @@ public class ResponseTest extends BaseServiceUnitTest {
     service.setServiceUrl(getMockWebServerUrl());
   }
 
-  /**
-   * Test that all fields are populated when calling execute().
-   */
   @Test
-  public void testExecuteTestModel() {
-    server.enqueue(new MockResponse().setBody(testResponseBody1));
+  public void testAllFieldsShouldBePopulatedWhenTheResponseIsPOJO() {
+    // Arrange
+    String expectedValue = "Columbus";
+    String responseBody = String.format("{\"city\": \"%s\"}", expectedValue);
+    server.enqueue(new MockResponse().setBody(responseBody));
 
-    Response<TestModel> response = service.getTestModel().execute();
+    // Act
+    Response<TestModel> response = service.getTestModelPOJO().execute();
+
+    // Assert
     assertNotNull(response.getResult());
-    assertEquals(testResponseValue, response.getResult().getCity());
+    assertEquals(expectedValue, response.getResult().getCity());
     assertNotNull(response.getHeaders());
   }
 
-  /**
-   * Test that a null result is returned when no response body is present.
-   */
   @Test
-  public void testExecuteTestModelNoResponse() {
-    server.enqueue(new MockResponse().setBody(testResponseBodyMissing));
+  public void testNullResultShouldReturnWhenNoResponse() {
+    // Arrange
+    String responseBody = "";
+    server.enqueue(new MockResponse().setBody(responseBody));
 
-    Response<TestModel> response = service.getTestModel().execute();
+    // Act
+    Response<TestModel> response = service.getTestModelPOJO().execute();
+
+    // Assert
     assertNull(response.getResult());
   }
 
-  /**
-   * Test an "empty" model instance is returned when an empty object response is present.
-   */
   @Test
-  public void testExecuteTestModelEmptyObject() {
-    server.enqueue(new MockResponse().setBody(testResponseBodyEmptyObject));
+  public void testShouldReturnEmptyModelWhenResponseIsAnEmptyObject() {
+    // Arrange
+    String responseBody = "{}";
+    server.enqueue(new MockResponse().setBody(responseBody));
 
-    Response<TestModel> response = service.getTestModel().execute();
+    // Act
+    Response<TestModel> response = service.getTestModelPOJO().execute();
+
+    // Assert
     TestModel obj = response.getResult();
     assertNotNull(obj);
     assertNull(obj.getCity());
   }
 
-  /**
-   * Test that an invalid JSON response results in an InvalidServiceResponseException.
-   */
   @Test(expectedExceptions = InvalidServiceResponseException.class)
-  public void testExecuteTestModelJSONError1() {
-    server.enqueue(new MockResponse().setBody(testResponseBodyError1));
-    service.getTestModel().execute();
+  public void testShouldThrowWhenJsonResponseIsInvalidJson() {
+    // Arrange
+    String responseBody = "{\"city\": \"Colum";
+    server.enqueue(new MockResponse().setBody(responseBody));
+
+    // Act
+    service.getTestModelPOJO().execute();
   }
 
-  /**
-   * Test that all fields are populated when calling enqueue().
-   *
-   * @throws InterruptedException the interrupted exception
-   */
   @Test
-  public void testEnqueue() throws InterruptedException {
-    server.enqueue(new MockResponse().setBody(testResponseBody1));
+  public void testShouldPopulateAllFieldsWhenCallingEnqueue() throws InterruptedException {
+    // Arrange
+    String expectedValueFromResultModel = "Columbus";
+    String responseBody = String.format("{\"city\": \"%s\"}", expectedValueFromResultModel);
+    server.enqueue(new MockResponse().setBody(responseBody));
 
     final Map<String, Object> results = new HashMap<>();
 
-    service.getTestModel().enqueue(new ServiceCallback<TestModel>() {
+    // Act
+    service.getTestModelPOJO().enqueue(new ServiceCallback<TestModel>() {
       @Override
       public void onResponse(Response<TestModel> response) {
         results.put("method", "onResponse");
@@ -216,28 +207,27 @@ public class ResponseTest extends BaseServiceUnitTest {
       }
     });
 
+    // Assert
     Thread.sleep(2000);
 
     assertEquals("onResponse", results.get("method"));
     Response<TestModel> response = (Response<TestModel>) results.get("response");
     assertNotNull(response);
     assertNotNull(response.getResult());
-    assertEquals(testResponseValue, response.getResult().getCity());
+    assertEquals(expectedValueFromResultModel, response.getResult().getCity());
     assertNotNull(response.getHeaders());
   }
 
-  /**
-   * Test that an invalid JSON response results in an InvalidServiceResponseException.
-   *
-   * @throws InterruptedException
-   */
   @Test
-  public void testEnqueueJSONError() throws InterruptedException{
-    server.enqueue(new MockResponse().setBody(testResponseBodyError1));
+  public void testShouldThrowWhenInvalidJsonIsEnqueued() throws InterruptedException{
+    // Arrange
+    String responseBody = "{\"city\": \"Colum";
+    server.enqueue(new MockResponse().setBody(responseBody));
 
     final Map<String, Object> results = new HashMap<>();
 
-    service.getTestModel().enqueue(new ServiceCallback<TestModel>() {
+    // Act
+    service.getTestModelPOJO().enqueue(new ServiceCallback<TestModel>() {
       @Override
       public void onResponse(Response<TestModel> response) {
         results.put("method", "onResponse");
@@ -250,6 +240,7 @@ public class ResponseTest extends BaseServiceUnitTest {
       }
     });
 
+    // Assert
     Thread.sleep(2000);
 
     assertEquals("onFailure", results.get("method"));
@@ -259,19 +250,19 @@ public class ResponseTest extends BaseServiceUnitTest {
   }
 
 
-  /**
-   * Test that a reactive request completes correctly.
-   *
-   * @throws InterruptedException
-   */
   @Test
-  public void testReactiveRequest() throws InterruptedException {
-    server.enqueue(new MockResponse().setBody(testResponseBody1));
+  public void testReactiveRequestShouldCompleteCorrectly() throws InterruptedException {
+    // Arrange
+    String expectedValue = "Columbus";
+    String responseBody = String.format("{\"city\": \"%s\"}", expectedValue);
+    server.enqueue(new MockResponse().setBody(responseBody));
 
     final Map<String, Object> results = new HashMap<>();
 
-    Single<Response<TestModel>> observableRequest = service.getTestModel().reactiveRequest();
+    // Act
+    Single<Response<TestModel>> observableRequest = service.getTestModelPOJO().reactiveRequest();
 
+    // Assert
     observableRequest
         .subscribeOn(Schedulers.single())
         .subscribe(new Consumer<Response<TestModel>>() {
@@ -288,20 +279,21 @@ public class ResponseTest extends BaseServiceUnitTest {
 
     Response<TestModel> response = (Response<TestModel>) results.get("response");
     assertNotNull(response);
-    assertEquals(testResponseValue, response.getResult().getCity());
+    assertEquals(expectedValue, response.getResult().getCity());
     assertNotNull(response.getHeaders());
   }
 
-  /**
-   * Test that headers are accessible from a HEAD method call using execute().
-   */
   @Test
-  public void testExecuteForHead() {
+  public void testHeadersShouldBeAccessible() {
+    // Arrange
     Headers rawHeaders = Headers.of("Content-Length", "472", "Content-Type", "application/json", "Server", "Mock");
     com.ibm.cloud.sdk.core.http.Headers expectedHeaders = new com.ibm.cloud.sdk.core.http.Headers(rawHeaders);
     server.enqueue(new MockResponse().setHeaders(rawHeaders));
 
+    // Act
     Response<Void> response = service.headMethod().execute();
+
+    // Assert
     com.ibm.cloud.sdk.core.http.Headers actualHeaders = response.getHeaders();
     assertNull(response.getResult());
     assertNotNull(actualHeaders);
@@ -314,41 +306,49 @@ public class ResponseTest extends BaseServiceUnitTest {
     assertEquals(expectedHeaders.toString(), actualHeaders.toString());
   }
 
-  /**
-   * Test that all fields are populated when calling execute().
-   */
   @Test
-  public void testExecuteTestModel2() {
-    server.enqueue(new MockResponse().setBody(testResponseBody1));
+  public void testAllFieldsShouldBePopulatedWhenResultIsGenericType() {
+    // Arrange
+    String expectedValue = "Columbus";
+    String responseBody = String.format("{\"city\": \"%s\"}", expectedValue);
+    server.enqueue(new MockResponse().setBody(responseBody));
 
-    Response<TestModel> response = service.getTestModel2().execute();
+    // Act
+    Response<TestModel> response = service.getTestModelGenericType().execute();
+
+    // Assert
     assertNotNull(response.getResult());
-    assertEquals(testResponseValue, response.getResult().getCity());
+    assertEquals(expectedValue, response.getResult().getCity());
     assertNotNull(response.getHeaders());
   }
 
-  /**
-   * Test that a list of strings response can be deserialized correctly.
-   */
   @Test
-  public void testExecuteString() {
-    server.enqueue(new MockResponse().setBody(testResponseBody5));
+  public void testShouldReturnStringDeserializedCorrectly() {
+    // Arrange
+    String expectedResult = "string response";
+    String responseBody = String.format("\"%s\"", expectedResult);
+    server.enqueue(new MockResponse().setBody(responseBody));
 
+    // Act
     Response<String> response = service.getString().execute();
+
+    // Assert
     String result = response.getResult();
     assertNotNull(result);
-    assertEquals("string response", result);
+    assertEquals(expectedResult, result);
     assertNotNull(response.getHeaders());
   }
 
-  /**
-   * Test that a list of strings response can be deserialized correctly.
-   */
   @Test
-  public void testExecuteListString() {
-    server.enqueue(new MockResponse().setBody(testResponseBody2));
+  public void testShouldReturnListOfStringsDeserializedCorrectly() {
+    // Arrange
+    String responseBody = "[\"string1\",\"string2\",\"string3\"]";
+    server.enqueue(new MockResponse().setBody(responseBody));
 
+    // Act
     Response<List<String>> response = service.getListString().execute();
+
+    // Arrange
     List<String> result = response.getResult();
     assertNotNull(result);
     assertEquals(result.size(), 3);
@@ -356,28 +356,33 @@ public class ResponseTest extends BaseServiceUnitTest {
     assertNotNull(response.getHeaders());
   }
 
-  /**
-   * Test that a list of strings response can be deserialized correctly.
-   */
   @Test
-  public void testExecuteLong() {
-    server.enqueue(new MockResponse().setBody(testResponseBody6));
+  public void testShouldReturnLongDeserializedCorrectly() {
+    // Arrange
+    String responseBody = "443374";
+    Long expectedResult = Long.parseLong(responseBody);
+    server.enqueue(new MockResponse().setBody(responseBody));
 
+    // Act
     Response<Long> response = service.getLong().execute();
+
+    // Assert
     Long result = response.getResult();
     assertNotNull(result);
-    assertEquals(Long.valueOf(443374), result);
+    assertEquals(expectedResult, result);
     assertNotNull(response.getHeaders());
   }
 
-  /**
-   * Test that a list of longs response can be deserialized correctly.
-   */
   @Test
-  public void testExecuteListLong() {
-    server.enqueue(new MockResponse().setBody(testResponseBody3));
+  public void testShouldReturnListOfLongsDeserializedCorrectly() {
+    // Arrange
+    String responseBody = "[44,33,74]";
+    server.enqueue(new MockResponse().setBody(responseBody));
 
+    // Act
     Response<List<Long>> response = service.getListLong().execute();
+
+    // Assert
     List<Long> result = response.getResult();
     assertNotNull(result);
     assertEquals(result.size(), 3);
@@ -395,10 +400,15 @@ public class ResponseTest extends BaseServiceUnitTest {
    * Test that list of TestModels response can be deserialized correctly.
    */
   @Test
-  public void testExecuteListTestModel() {
-    server.enqueue(new MockResponse().setBody(testResponseBody4));
+  public void testShouldReturnListOfObjectDeserializedCorrectly() {
+    // Arrange
+    String responseBody = "[{\"city\":\"Austin\"},{\"city\":\"Georgetown\"},{\"city\":\"Cedar Park\"}]";
+    server.enqueue(new MockResponse().setBody(responseBody));
 
+    // Act
     Response<List<TestModel>> response = service.getListTestModel().execute();
+
+    // Assert
     List<TestModel> result = response.getResult();
     assertNotNull(result);
     assertEquals(result.size(), 3);
@@ -410,66 +420,71 @@ public class ResponseTest extends BaseServiceUnitTest {
     assertNotNull(response.getHeaders());
   }
 
-  /**
-   * Test that a null list is returned when response body is missing.
-   */
   @Test
-  public void testExecuteListTestModelNoResponse() {
-    server.enqueue(new MockResponse().setBody(testResponseBodyMissing));
+  public void testShouldReturnNullListWhenResponseBodyIsMissing() {
+    // Arrange
+    String responseBody = "";
+    server.enqueue(new MockResponse().setBody(responseBody));
 
+    // Act
     Response<List<TestModel>> response = service.getListTestModel().execute();
+
+    // Assert
     List<TestModel> list = response.getResult();
     assertNull(list);
   }
 
-  /**
-   * Test that an empty list of TestModels are returned when response body is "[]".
-   */
   @Test
-  public void testExecuteListTestModelEmptyList() {
-    server.enqueue(new MockResponse().setBody(testResponseBodyEmptyList));
+  public void testShouldReturnEmptyListWhenResponseBodyIsAnEmptyList() {
+    // Arrange
+    String responseBody = "[]";
+    server.enqueue(new MockResponse().setBody(responseBody));
 
+    // Act
     Response<List<TestModel>> response = service.getListTestModel().execute();
+
+    // Assert
     List<TestModel> list = response.getResult();
     assertNotNull(list);
     assertTrue(list.isEmpty());
   }
 
-  /**
-   * Test getting the status code from a response.
-   */
   @Test
-  public void testResponseCode() {
+  public void testShouldReturnTheExpectedResponseCode() {
+    // Arrange
     server.enqueue(new MockResponse().setResponseCode(204));
+
+    // Act
     Response<Void> response = service.headMethod().execute();
+
+    // Assert
     assertEquals(204, response.getStatusCode(), "The response status code should be 204.");
   }
 
-  /**
-   * Test getting the status line message from a response.
-   */
   @Test
-  public void testResponseMessage() {
+  public void testShouldBeAbleToRetrieveStatusLineFromResponseMessage() {
+    // Arrange
     server.enqueue(new MockResponse().setStatus("HTTP/1.1 204 No Content"));
+
+    // Act
     Response<Void> response = service.headMethod().execute();
+
+    // Assert
     assertEquals("No Content", response.getStatusMessage(), "The response status message should be 'No Content'.");
   }
 
-  /**
-   * Test canceling a service call by mimicking setting a timeout and canceling if the call exceeds that value.
-   *
-   * @throws InterruptedException the interrupted exception
-   */
   @Test
-  public void testRequestCancel() throws InterruptedException {
-    server.enqueue(new MockResponse().setBody(testResponseBody1).setBodyDelay(5000, TimeUnit.MILLISECONDS));
+  public void testShouldBeAbleToCancelRequestCall() throws InterruptedException {
+    // Arrange
+    String responseBody = "{\"city\": \"Columbus\"}";
+    server.enqueue(new MockResponse().setBody(responseBody).setBodyDelay(5000, TimeUnit.MILLISECONDS));
 
     // time to consider timeout (in ms)
     long timeoutThreshold = 3000;
     final boolean[] hasCallCompleted = {false};
     final boolean[] callWasCanceled = {false};
 
-    ServiceCall<TestModel> testCall = service.getTestModel();
+    ServiceCall<TestModel> testCall = service.getTestModelPOJO();
     long startTime = Clock.getCurrentTimeInMillis();
     testCall.enqueue(new ServiceCallback<TestModel>() {
       @Override
@@ -491,10 +506,12 @@ public class ResponseTest extends BaseServiceUnitTest {
     }
 
     // if we timed out and it's STILL not complete, we'll just cancel the call
+    // Act
     if (!hasCallCompleted[0]) {
       testCall.cancel();
     }
 
+    // Assert
     // sleep for a bit to make sure all async operations are complete, and then verify we set this value
     // in onFailure()
     Thread.sleep(500);


### PR DESCRIPTION
This PR brings unit test improvements for `ResponseConverterUtils` and `ResponseUtils` classes.

**Notes**:
- I took the liberty refactoring the tests into AAA format (without changing what and how they do), and moving the input parameters into the tests, renaming the methods and removing documentation headers. As the volume of test cases grew it was difficult to scroll back and fort between the method and the input values placed on the top of the file.
- I also renamed the methods of the test service so they tells more about which underlying `ResponseConverterUtils` method is called
- I extended the already implemented positive test cases with negative tests for having some coverage on corner cases
- there are seemingly superflous test cases, I added these to document the existing behavior
- streaming is not covered yet, it will be done by a later PR 

Coverage before PR:
<img width="1133" alt="Screenshot 2021-07-26 at 20 26 12" src="https://user-images.githubusercontent.com/5106373/127039767-1c60ef39-2859-4a09-b219-f307db14519a.png">

Coverage by this PR:
<img width="1150" alt="Screenshot 2021-07-26 at 20 04 23" src="https://user-images.githubusercontent.com/5106373/127039827-93944a04-b229-40ec-8069-915ae488b2b0.png">
