### PR TITLE
fix(http): avoid gzipping zero length content

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/http/gzip/GzipRequestInterceptor.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/gzip/GzipRequestInterceptor.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2015, 2020.
+ * (C) Copyright IBM Corp. 2015, 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -28,7 +28,9 @@ import okio.Okio;
 public final class GzipRequestInterceptor implements Interceptor {
     @Override public Response intercept(Interceptor.Chain chain) throws IOException {
       Request originalRequest = chain.request();
-      if (originalRequest.body() == null || originalRequest.header("Content-Encoding") != null) {
+      if (originalRequest.body() == null
+          || originalRequest.body().contentLength() == 0L
+          || originalRequest.header("Content-Encoding") != null) {
         return chain.proceed(originalRequest);
       }
 


### PR DESCRIPTION
There is no value in compressing something of zero-length and this helps resolve a quirky problem.

OkHttp appears to [send `DELETE` requests](https://github.com/square/okhttp/issues/654) with a zero length (as opposed to `null` body). Since the compressed length is not known in advance a compressed zero length body is sent chunked, which requires the receiving server to read the [non-existent] body (as it doesn't know it is empty). Some servers don't expect a body on `DELETE` requests (because the spec is ambiguous on the matter) and then fail to handle the `DELETE` request. If the body isn't compressed we avoid this bad path.

Added a test that verfies the compression is bypassed for a `DELETE` request with zero length.