### PR TITLE
chore(build): fix gpg import

### DIFF
--- a/build/setupSigning.sh
+++ b/build/setupSigning.sh
@@ -13,7 +13,7 @@ echo "Importing signing key..."
 openssl aes-256-cbc -K $encrypted_4b7d603e7466_key -iv $encrypted_4b7d603e7466_iv -in build/signing.key.enc -out build/signing.key -d
 
 gpg --version
-gpg --fast-import build/signing.key
+gpg --batch --import build/signing.key
 rm build/signing.key
 
 echo "Signing key import finished!"


### PR DESCRIPTION
This PR fixes the gpg import step for the "bionic" travis image.   This is needed due to the fact that "bionic" uses a more recent version of the "gpg" command.