### PR TITLE
fix: Prevent double entries of Authorization header on second authenticate call

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-08-07T17:12:28Z",
+  "generated_at": "2021-10-05T00:34:30Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -130,7 +130,7 @@
         "hashed_secret": "ffac6ba71b03ca5f5012197511d76fbcfcf62fbf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 36,
+        "line_number": 37,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -322,7 +322,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.40.dss",
+  "version": "0.13.1+ibm.46.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/src/main/java/com/ibm/cloud/sdk/core/security/BasicAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/BasicAuthenticator.java
@@ -200,6 +200,6 @@ public class BasicAuthenticator extends AuthenticatorBase implements Authenticat
    */
   @Override
   public void authenticate(okhttp3.Request.Builder builder) {
-    builder.addHeader(HttpHeaders.AUTHORIZATION, this.authHeader);
+    builder.header(HttpHeaders.AUTHORIZATION, this.authHeader);
   }
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/security/BearerTokenAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/BearerTokenAuthenticator.java
@@ -107,6 +107,6 @@ public class BearerTokenAuthenticator extends AuthenticatorBase implements Authe
    */
   @Override
   public void authenticate(Builder builder) {
-    builder.addHeader(HttpHeaders.AUTHORIZATION, this.cachedAuthHeader);
+    builder.header(HttpHeaders.AUTHORIZATION, this.cachedAuthHeader);
   }
 }

--- a/src/main/java/com/ibm/cloud/sdk/core/security/TokenRequestBasedAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/TokenRequestBasedAuthenticator.java
@@ -159,7 +159,7 @@ public abstract class TokenRequestBasedAuthenticator<T extends AbstractToken, R 
   public void authenticate(Builder builder) {
     String headerValue = constructBearerTokenAuthHeader(getToken());
     if (headerValue != null) {
-      builder.addHeader(HttpHeaders.AUTHORIZATION, headerValue);
+      builder.header(HttpHeaders.AUTHORIZATION, headerValue);
     }
   }
 

--- a/src/test/java/com/ibm/cloud/sdk/core/test/BaseServiceUnitTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/BaseServiceUnitTest.java
@@ -30,10 +30,12 @@ import org.powermock.modules.testng.PowerMockTestCase;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static com.ibm.cloud.sdk.core.http.HttpHeaders.CONTENT_TYPE;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -126,7 +128,9 @@ public class BaseServiceUnitTest extends PowerMockTestCase {
   // Verify the Authorization header in the specified request builder.
   protected void verifyAuthHeader(Request.Builder builder, String expectedPrefix) {
     Request request = builder.build();
-    String actualValue = request.header(HttpHeaders.AUTHORIZATION);
+    List<String> authHeaders = request.headers(HttpHeaders.AUTHORIZATION);
+    assertEquals(authHeaders.size(), 1);
+    String actualValue = authHeaders.get(0);
     assertNotNull(actualValue);
 
     assertTrue(actualValue.startsWith(expectedPrefix));

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/BasicAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/BasicAuthenticatorTest.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @SuppressWarnings("deprecation")
@@ -223,5 +224,23 @@ public class BasicAuthenticatorTest {
     assertEquals(Authenticator.AUTHTYPE_BASIC, authenticator.authenticationType());
     assertEquals("good-username", authenticator.getUsername());
     assertEquals("good-password", authenticator.getPassword());
+  }
+
+  @Test
+  public void testSingleAuthHeader() {
+    String username = "good-username";
+    Map<String, String> props = new HashMap<>();
+    props.put(Authenticator.PROPNAME_USERNAME, "good-username");
+    props.put(Authenticator.PROPNAME_PASSWORD, "good-password");
+    BasicAuthenticator auth = new BasicAuthenticator(props);
+
+    Request.Builder requestBuilder = new Request.Builder().url("https://test.com");
+    auth.authenticate(requestBuilder);
+    // call authenticate twice on the same request
+    auth.authenticate(requestBuilder);
+    Request request = requestBuilder.build();
+
+    List<String> authHeaders = request.headers(HttpHeaders.AUTHORIZATION);
+    assertEquals(authHeaders.size(), 1);
   }
 }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/BearerTokenAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/BearerTokenAuthenticatorTest.java
@@ -17,6 +17,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.testng.annotations.Test;
@@ -107,5 +108,21 @@ public class BearerTokenAuthenticatorTest {
     BearerTokenAuthenticator authenticator = BearerTokenAuthenticator.fromConfiguration(props);
     assertEquals(Authenticator.AUTHTYPE_BEARER_TOKEN, authenticator.authenticationType());
     assertEquals("my-access-token", authenticator.getBearerToken());
+  }
+
+  @Test
+  public void testSingleAuthHeader() {
+    Map<String, String> props = new HashMap<>();
+    props.put(Authenticator.PROPNAME_BEARER_TOKEN, "my-access-token");
+    BearerTokenAuthenticator auth = BearerTokenAuthenticator.fromConfiguration(props);
+
+    Request.Builder requestBuilder = new Request.Builder().url("https://test.com");
+    auth.authenticate(requestBuilder);
+    // call authenticate twice on the same request
+    auth.authenticate(requestBuilder);
+    Request request = requestBuilder.build();
+
+    List<String> authHeaders = request.headers(HttpHeaders.AUTHORIZATION);
+    assertEquals(authHeaders.size(), 1);
   }
 }


### PR DESCRIPTION
When `authenticate` method called by `BasicAuthenticator`, `BearerTokenAuthenticator` or `TokenRequestBasedAuthenticator` second time on the same request it adds second `Authorization` header to the request. This can lead to a consecutive failure with `400` error from the services with strict rules about headers' double entries.

This PR switches named authenticators to use `builder.header` method to prevent that.
