### PR TITLE
chore: avoid logback vuln alert

### DIFF
--- a/.cra/.cveignore
+++ b/.cra/.cveignore
@@ -1,0 +1,6 @@
+[
+  {
+    "cve": "SNYK-JAVA-CHQOSLOGBACK-1726923",
+    "untilRemediationAvailable": true
+  }
+]


### PR DESCRIPTION
This PR adds the .cra/.cveignore file to avoid the logback-core vulnerability alert until a fix is available .