### PR TITLE
fix: bump gson dependency to 2.8.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <okhttp3-version>4.9.1</okhttp3-version>
         <logback-version>1.2.6</logback-version>
         <guava-version>30.1.1-jre</guava-version>
-        <gson-version>2.8.7</gson-version>
+        <gson-version>2.8.9</gson-version>
         <commons-codec-version>1.15</commons-codec-version>
         <commons-io-version>2.7</commons-io-version>
         <commons-lang3-version>3.8.1</commons-lang3-version>


### PR DESCRIPTION
This commit addresses a gson-related security vulnerability by upgrading our gson dependency to version 2.8.9 (the current latest).