### PR TITLE
fix: set gson's objectToNumber policy to DOUBLE

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/util/GsonSingleton.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/GsonSingleton.java
@@ -47,7 +47,7 @@ public final class GsonSingleton {
    */
   private static Gson createGson(boolean prettyPrint, boolean serializeNulls) {
     GsonBuilder builder = new GsonBuilder()
-        .setObjectToNumberStrategy(ToNumberPolicy.LAZILY_PARSED_NUMBER)
+        .setObjectToNumberStrategy(ToNumberPolicy.DOUBLE)
         .setNumberToNumberStrategy(ToNumberPolicy.LAZILY_PARSED_NUMBER);
 
     registerTypeAdapters(builder);


### PR DESCRIPTION
When the java core was recently upgraded to gson version 2.8.9,
that included a change to set gson's "objectToNumber"
policy to be "LAZILY_PARSED_NUMBER", but that was incorrect.
It should be set to "DOUBLE".
This commit makes this change, which means that if a JSON string
is unmarshalled into a generic Map<String, Object>, then any
JSON "number" values that are encountered will now be unmarshalled
into a Double instead of a LazilyParsedNumber.
This change restores the behavior seen in gson versions prior to
2.8.9 (and java core versions prior to 9.13.4).