### PR TITLE
fix: update logback version to fix vulnerability

### DIFF
--- a/.cra/.cveignore
+++ b/.cra/.cveignore
@@ -1,6 +1,2 @@
 [
-  {
-    "cve": "SNYK-JAVA-CHQOSLOGBACK-1726923",
-    "untilRemediationAvailable": true
-  }
 ]

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <jacoco-plugin-version>0.8.3</jacoco-plugin-version>
         <compiler-plugin-version>3.8.0</compiler-plugin-version>
         <okhttp3-version>4.9.1</okhttp3-version>
-        <logback-version>1.2.6</logback-version>
+        <logback-version>1.2.7</logback-version>
         <guava-version>30.1.1-jre</guava-version>
         <gson-version>2.8.9</gson-version>
         <commons-codec-version>1.15</commons-codec-version>


### PR DESCRIPTION
Logback core module recently added a `1.2.7` version that fixes an existing vulnerability. This updates to that new version.