### PR TITLE
WIP: Fix test failures that occur with "nondex" plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,12 @@
             <version>${powermock-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/ibm/cloud/sdk/core/service/model/DynamicModel.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/model/DynamicModel.java
@@ -13,7 +13,7 @@
 
 package com.ibm.cloud.sdk.core.service.model;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -27,7 +27,7 @@ public abstract class DynamicModel<T> implements ObjectModel {
   private TypeToken<T> additionalPropertyTypeToken;
 
   // The set of dynamic properties associated with this object.
-  private Map<String, T> dynamicProperties = new HashMap<>();
+  private Map<String, T> dynamicProperties = new LinkedHashMap<>();
 
   /**
    * Force use of 1-arg ctor.
@@ -85,7 +85,7 @@ public abstract class DynamicModel<T> implements ObjectModel {
    *         a map containing arbitrary properties to set on this object
    */
   public void setProperties(Map<String, T> properties) {
-    this.dynamicProperties = new HashMap<String, T>();
+    this.dynamicProperties = new LinkedHashMap<String, T>();
     if (properties != null) {
       this.dynamicProperties.putAll(properties);
     }
@@ -97,7 +97,7 @@ public abstract class DynamicModel<T> implements ObjectModel {
    * @return a copy of the map containing arbitrary properties set on this object
    */
   public Map<String, T> getProperties() {
-    return new HashMap<String, T>(this.dynamicProperties);
+    return new LinkedHashMap<String, T>(this.dynamicProperties);
   }
 
   /**

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestBuilderTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestBuilderTest.java
@@ -25,6 +25,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
 import org.testng.annotations.Test;
 
 import com.google.gson.JsonObject;
@@ -211,9 +213,10 @@ public class RequestBuilderTest {
    * Test with list of models.
    *
    * @throws IOException Signals that an I/O exception has occurred.
+   * @throws JSONException Signals that a JSON parsing error has occured.
    */
   @Test
-  public void testBodyContentList() throws IOException {
+  public void testBodyContentList() throws IOException, JSONException {
     // add list of actual models
     final List<Vehicle> listOfModels = new ArrayList<>();
     listOfModels.add(new Truck.Builder().vehicleType("Truck").make("Ford").engineType("raptor").build());
@@ -224,8 +227,11 @@ public class RequestBuilderTest {
     final RequestBody requestedBody = request.body();
     final Buffer buffer = new Buffer();
     requestedBody.writeTo(buffer);
-
-    assertEquals(GsonSingleton.getGsonWithoutPrettyPrinting().toJson(listOfModels), buffer.readUtf8());
+    try {
+      JSONAssert.assertEquals(GsonSingleton.getGsonWithoutPrettyPrinting().toJson(listOfModels), buffer.readUtf8(), false);
+    } catch (JSONException e) {
+      throw e;
+    }
     assertEquals(HttpMediaType.JSON, requestedBody.contentType());
   }
 
@@ -475,17 +481,21 @@ public class RequestBuilderTest {
   /**
    * Test bodyContent() with a model instance.
    * @throws IOException
+   * @throws JSONException
    */
   @Test
-  public void testBodyContent1() throws IOException {
+  public void testBodyContent1() throws IOException, JSONException {
     Truck truck = new Truck.Builder().vehicleType("Truck").make("Ford").engineType("raptor").build();
     final Request request = RequestBuilder.post(HttpUrl.parse(urlWithQuery))
         .bodyContent("application/json", truck, null, (InputStream) null).build();
     final RequestBody requestedBody = request.body();
     final Buffer buffer = new Buffer();
     requestedBody.writeTo(buffer);
-
-    assertEquals(GsonSingleton.getGsonWithoutPrettyPrinting().toJson(truck), buffer.readUtf8());
+    try {
+      JSONAssert.assertEquals(GsonSingleton.getGsonWithoutPrettyPrinting().toJson(truck), buffer.readUtf8(), false);
+    } catch (JSONException e) {
+      throw e;
+    }
     assertEquals(HttpMediaType.JSON, requestedBody.contentType());
   }
 
@@ -502,7 +512,6 @@ public class RequestBuilderTest {
     final RequestBody requestedBody = request.body();
     final Buffer buffer = new Buffer();
     requestedBody.writeTo(buffer);
-
     assertEquals(jsonString, buffer.readUtf8());
     assertEquals(MediaType.parse("application/json"), requestedBody.contentType());
   }
@@ -510,9 +519,10 @@ public class RequestBuilderTest {
   /**
    * Test bodyContent() with a multiple inputs (JSON input should win).
    * @throws IOException
+   * @throws JSONException
    */
   @Test
-  public void testBodyContent3() throws IOException {
+  public void testBodyContent3() throws IOException, JSONException {
     Truck truck = new Truck.Builder().vehicleType("Truck").make("Ford").engineType("raptor").build();
     final Request request = RequestBuilder.post(HttpUrl.parse(urlWithQuery))
         .bodyContent("application/json", truck, "BAD JSON PATCH BODY", "BAD INPUTSTREAM REQUEST BODY").build();
@@ -520,7 +530,11 @@ public class RequestBuilderTest {
     final Buffer buffer = new Buffer();
     requestedBody.writeTo(buffer);
 
-    assertEquals(GsonSingleton.getGsonWithoutPrettyPrinting().toJson(truck), buffer.readUtf8());
+    try {
+      JSONAssert.assertEquals(GsonSingleton.getGsonWithoutPrettyPrinting().toJson(truck), buffer.readUtf8(), false);
+    } catch (JSONException e) {
+      throw e;
+    }
     assertEquals(HttpMediaType.JSON, requestedBody.contentType());
   }
 

--- a/src/test/java/com/ibm/cloud/sdk/core/util/RequestUtilsTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/RequestUtilsTest.java
@@ -69,8 +69,10 @@ public class RequestUtilsTest {
   public void testOmitWithNulls() {
     final Map<String, Object> params = createMap();
 
-    assertEquals(params.keySet().toArray(), RequestUtils.omit(params).keySet().toArray());
-    assertEquals(params.values().toArray(), RequestUtils.omit(params).values().toArray());
+    Map<String, Object> omitted = RequestUtils.omit(params);
+
+    assertTrue(omitted.keySet().containsAll(Lists.newArrayList("A", "B", "C", "D")));
+    assertTrue(omitted.values().containsAll(Lists.newArrayList(1, 2, 3, 4)));
 
     assertNull(RequestUtils.omit(null));
   }
@@ -97,9 +99,11 @@ public class RequestUtilsTest {
   @Test
   public void testPickWithNulls() {
     final Map<String, Object> params = createMap();
+    
+    Map<String, Object> omitted = RequestUtils.omit(params);
 
-    assertEquals(params.keySet().toArray(), RequestUtils.pick(params).keySet().toArray());
-    assertEquals(params.values().toArray(), RequestUtils.pick(params).values().toArray());
+    assertTrue(omitted.keySet().containsAll(Lists.newArrayList("A", "B", "C", "D")));
+    assertTrue(omitted.values().containsAll(Lists.newArrayList(1, 2, 3, 4)));
 
     assertNull(RequestUtils.pick(null));
   }


### PR DESCRIPTION
This PR fixes several flaky tests:
1. There are several flaky tests in DynamicModelSerializationTest. The root cause of them is that `equals()` compares two `HashMap<String, T> dynamicProperties` in `DynamicModel`.
In this PR, `LinkedHashMap` is used instead of `HashMap` to resolve the ordering issue. This solution considers 2 `DynamicModel`s are same if their elements have the same insertion order. However, the `equals()` function should be modified to completely resolve the ordering issue.
2. There are several flaky tests in RequestBuilderTest. In these tests multiple pairs of JSON strings are compared with each other.
In this PR, `JSONAssert` library is used to ignore the order difference when comparing 2 JSON strings.
3. There are a couple of flaky test in RequestUtilsTest. The root cause of them is the inconsistency when comparing 2 maps.
In this PR, the comparations are changed to match the style of other tests in the same files while ignoring the ordering issue.