### PR TITLE
fix: remove unnecessary logback dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
         <jacoco-plugin-version>0.8.3</jacoco-plugin-version>
         <compiler-plugin-version>3.8.0</compiler-plugin-version>
         <okhttp3-version>4.9.1</okhttp3-version>
-        <logback-version>1.2.7</logback-version>
         <guava-version>30.1.1-jre</guava-version>
         <gson-version>2.8.9</gson-version>
         <commons-codec-version>1.15</commons-codec-version>
@@ -111,12 +110,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>${logback-version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>


### PR DESCRIPTION
This PR removes the dependency for logback-classic (which in turn pulled in logback-core).
Because the java core code uses the java.util.logging interface, there is no need for logback at all.