### PR TITLE
build: refine criteria for semrel build stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ env:
 stages:
   - name: Build-Test
   - name: Semantic-Release
-    if: branch = main AND type = push AND fork = false
+    if: (branch = main) AND (type IN (push, api)) AND (fork = false)
   - name: Publish-Release
-    if: tag IS present
+    if: (tag IS present) AND (fork = false)
 
 before_install:
   - sudo apt-get update


### PR DESCRIPTION
This commit removes the "type = push" criteria from the semrel build stage so that we can manually trigger a build of the main branch and also cause the semrel stage to fire.   This was needed because for a manually triggered build, the build type is "api" and not "push".