### PR TITLE
feat: support user-defined retry interceptors

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-11-17T14:53:46Z",
+  "generated_at": "2022-03-16T14:20:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -150,7 +150,7 @@
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 62,
+        "line_number": 63,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -158,7 +158,7 @@
         "hashed_secret": "2207d3f3ac68743290fe4affc71c10bec4962232",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 63,
+        "line_number": 64,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -352,7 +352,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.46.dss",
+  "version": "0.13.1+ibm.47.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/src/main/java/com/ibm/cloud/sdk/core/http/DefaultRetryStrategy.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/DefaultRetryStrategy.java
@@ -1,0 +1,28 @@
+/**
+ * (C) Copyright IBM Corp. 2022.  All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.sdk.core.http;
+
+import com.ibm.cloud.sdk.core.security.Authenticator;
+
+/**
+ * This is the java core's default retry strategy.
+ * It will return instances of our RetryInterceptor implementation class.
+ */
+public class DefaultRetryStrategy implements IRetryStrategy {
+
+  @Override
+  public RetryInterceptor createRetryInterceptor(int maxRetries, int maxRetryInterval, Authenticator authenticator) {
+    return new RetryInterceptor(maxRetries, maxRetryInterval, authenticator);
+  }
+}

--- a/src/main/java/com/ibm/cloud/sdk/core/http/IRetryInterceptor.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/IRetryInterceptor.java
@@ -1,0 +1,24 @@
+/**
+ * (C) Copyright IBM Corp. 2022.  All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.sdk.core.http;
+
+import okhttp3.Interceptor;
+
+/**
+ * This is a marker interface used to identify retry interceptor implementations
+ * within the java core library.
+ */
+public interface IRetryInterceptor extends Interceptor {
+
+}

--- a/src/main/java/com/ibm/cloud/sdk/core/http/IRetryStrategy.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/IRetryStrategy.java
@@ -1,0 +1,39 @@
+/**
+ * (C) Copyright IBM Corp. 2022.  All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.sdk.core.http;
+
+import com.ibm.cloud.sdk.core.security.Authenticator;
+
+/**
+ * IRetryStrategy is an interface that is implemented by retry interceptor factories.
+ * This interface is used by the java core to create a retry interceptor implementation when
+ * automatic retries are enabled.
+ * The java core defines a default implementation of this interface in the
+ * DefaultRetryStrategy class.
+ * Users can implement their own factory in order to supply their own retry interceptor
+ * implementation, perhaps to customize the criteria under which failed requests will be retried.
+ */
+public interface IRetryStrategy {
+
+  /**
+   * Return an implementation of the {@link IRetryInterceptor} interface
+   * that is capable of retrying failed requests.
+   *
+   * @param maxRetries the maximum number of retries to be attempted by the retry interceptor
+   * @param maxRetryInterval the maximum interval (in seconds)
+   * @param authenticator the Authenticator instance to be used to authenticate retried requests
+   * @return an okhttp3.Interceptor instance
+   */
+  IRetryInterceptor createRetryInterceptor(int maxRetries, int maxRetryInterval, Authenticator authenticator);
+}


### PR DESCRIPTION
This commit provides a pluggable way for users of the java core
to supply their own retry interceptor implementation in order
to customize the conditions under which retries are automatically
attempted.
Included in these changes is the notion of a "retry strategy",
which is a factory for creating retry interceptor instances.
Users of the java core (e.g. an SDK project) can implement
their own retry strategy and then set it with the
HttpClientSingleton.setRetryStrategy() static method.
Once set, the registered factory's createRetryInterceptor()
method will be called whenever the java core needs to initialize an
http client instance when retries are enabled.
The factory's createRetryInterceptor() method returns an implementation
of the IRetryInterceptor interface (which is itself a subclass of
the okhttp3 Interceptor interface).
User's might find it convenient to define their retry interceptor
class as a subclass of the java core's RetryInterceptor class,
thereby relying on RetryInterceptor for most of the functionality,
while overriding specific methods as needed.