### PR TITLE
fix: bump gson to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <compiler-plugin-version>3.8.0</compiler-plugin-version>
         <okhttp3-version>4.9.1</okhttp3-version>
         <guava-version>30.1.1-jre</guava-version>
-        <gson-version>2.8.9</gson-version>
+        <gson-version>2.9.0</gson-version>
         <commons-codec-version>1.15</commons-codec-version>
         <commons-io-version>2.7</commons-io-version>
         <commons-lang3-version>3.8.1</commons-lang3-version>

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/DynamicModelTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/DynamicModelTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2015, 2019.
+ * (C) Copyright IBM Corp. 2015, 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 import com.ibm.cloud.sdk.core.test.model.generated.AnimalCat;
 
 /**
- * A few simple tests that exercise the GenericModel methods.
+ * A few simple tests that exercise the DynamicModel methods.
  */
 public class DynamicModelTest {
   private boolean displayOutput = false;


### PR DESCRIPTION
This PR bumps our gson dependency to the current latest (2.9.0).
Included in this are changes to wean us off the GSON ReflectionAccessor class, which is no longer present in v2.9.0.