### PR TITLE
build: add travis stage for java 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,11 @@ jobs:
       script:
         - mvn clean package $MVN_ARGS
 
+    - jdk: openjdk17
+      install: skip
+      script:
+        - mvn clean package $MVN_ARGS
+
     - stage: Semantic-Release
       jdk: openjdk8
       install:


### PR DESCRIPTION
This PR adds a build stage to the travis build config that will build & test the project using java 17 (openjdk17)