### PR TITLE
feat: allow user-specified default OkHttpClient instance

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/http/HttpClientSingleton.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/HttpClientSingleton.java
@@ -153,7 +153,25 @@ public class HttpClientSingleton {
   }
 
   /**
-   * Configures the HTTP client.
+   * Returns the current {@link OkHttpClient} instance held by this singleton.
+   * This is the client instance that is used as a default configuration from which other client instances are built.
+   * @return the current OkHttpClient instance
+   */
+  public OkHttpClient getHttpClient() {
+    return this.okHttpClient;
+  }
+
+  /**
+   * Sets the current {@link OkHttpClient} instance held by this singleton.
+   * This is the client instance that is used as a default configuration from which other client instances are built.
+   * @param client the new OkHttpClient instance to use as a default client configuration
+   */
+  public void setHttpClient(OkHttpClient client) {
+    this.okHttpClient = client;
+  }
+
+  /**
+   * Configures a new HTTP client instance.
    *
    * @return the HTTP client
    */
@@ -290,7 +308,7 @@ public class HttpClientSingleton {
    *
    * @param builder the {@link OkHttpClient} builder.
    */
-  private void setupTLSProtocol(final OkHttpClient.Builder builder) {
+  public static void setupTLSProtocol(final OkHttpClient.Builder builder) {
     try {
       TrustManagerFactory trustManagerFactory =
           TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());

--- a/src/test/java/com/ibm/cloud/sdk/core/security/VpcInstanceAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/security/VpcInstanceAuthenticatorTest.java
@@ -20,6 +20,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -38,7 +39,9 @@ import com.ibm.cloud.sdk.core.service.exception.ServiceResponseException;
 import com.ibm.cloud.sdk.core.test.BaseServiceUnitTest;
 import com.ibm.cloud.sdk.core.util.Clock;
 
+import okhttp3.ConnectionSpec;
 import okhttp3.Headers;
+import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.mockwebserver.RecordedRequest;
 
@@ -404,6 +407,19 @@ public class VpcInstanceAuthenticatorTest extends BaseServiceUnitTest {
         .url(url)
         .build();
 
+    // Create a custom client and set it on the authenticator.
+    ConnectionSpec spec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+        .allEnabledCipherSuites()
+        .build();
+    OkHttpClient client = new OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(120, TimeUnit.SECONDS)
+        .readTimeout(120, TimeUnit.SECONDS)
+        .connectionSpecs(Arrays.asList(spec, ConnectionSpec.CLEARTEXT))
+        .build();
+    authenticator.setClient(client);
+    assertEquals(authenticator.getClient(), client);
+
     Request.Builder requestBuilder = new Request.Builder().url("https://test.com");
 
     // Set mock server responses.
@@ -422,6 +438,9 @@ public class VpcInstanceAuthenticatorTest extends BaseServiceUnitTest {
     requestBuilder = new Request.Builder().url("https://test.com");
     authenticator.authenticate(requestBuilder);
     verifyAuthHeader(requestBuilder, "Bearer " + vpcIamAccessTokenResponse1.getAccessToken());
+
+    // Verify that the authenticator is still using the same client instance that we set before.
+    assertEquals(authenticator.getClient(), client);
   }
 
   @Test

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dAuthenticatorTest.java
@@ -21,6 +21,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -39,7 +40,9 @@ import com.ibm.cloud.sdk.core.service.exception.ServiceResponseException;
 import com.ibm.cloud.sdk.core.test.BaseServiceUnitTest;
 import com.ibm.cloud.sdk.core.util.Clock;
 
+import okhttp3.ConnectionSpec;
 import okhttp3.Headers;
+import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.mockwebserver.RecordedRequest;
 
@@ -312,10 +315,22 @@ public class Cp4dAuthenticatorTest extends BaseServiceUnitTest {
         .password(testPassword)
         .disableSSLVerification(true)
         .build();
-    Request.Builder requestBuilder;
+
+    // Create a custom client and set it on the authenticator.
+    ConnectionSpec spec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+        .allEnabledCipherSuites()
+        .build();
+    OkHttpClient client = new OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(120, TimeUnit.SECONDS)
+        .readTimeout(120, TimeUnit.SECONDS)
+        .connectionSpecs(Arrays.asList(spec, ConnectionSpec.CLEARTEXT))
+        .build();
+    authenticator.setClient(client);
+    assertEquals(authenticator.getClient(), client);
 
     // Authenticator should request new, valid token.
-    requestBuilder = new Request.Builder().url("https://test.com");
+     Request.Builder requestBuilder = new Request.Builder().url("https://test.com");
     authenticator.authenticate(requestBuilder);
     verifyAuthHeader(requestBuilder, "Bearer " + tokenData.getToken());
 
@@ -323,6 +338,9 @@ public class Cp4dAuthenticatorTest extends BaseServiceUnitTest {
     requestBuilder = new Request.Builder().url("https://test.com");
     authenticator.authenticate(requestBuilder);
     verifyAuthHeader(requestBuilder, "Bearer " + tokenData.getToken());
+
+    // Verify that the authenticator is still using the same client instance that we set before.
+    assertEquals(authenticator.getClient(), client);
   }
 
   @Test

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dServiceInstanceAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dServiceInstanceAuthenticatorTest.java
@@ -21,6 +21,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -38,7 +39,9 @@ import com.ibm.cloud.sdk.core.service.exception.ServiceResponseException;
 import com.ibm.cloud.sdk.core.test.BaseServiceUnitTest;
 import com.ibm.cloud.sdk.core.util.Clock;
 
+import okhttp3.ConnectionSpec;
 import okhttp3.Headers;
+import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.mockwebserver.RecordedRequest;
 
@@ -345,10 +348,22 @@ public class Cp4dServiceInstanceAuthenticatorTest extends BaseServiceUnitTest {
         .serviceInstanceId(testServiceInstanceId)
         .disableSSLVerification(true)
         .build();
-    Request.Builder requestBuilder;
+
+    // Create a custom client and set it on the authenticator.
+    ConnectionSpec spec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+        .allEnabledCipherSuites()
+        .build();
+    OkHttpClient client = new OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(120, TimeUnit.SECONDS)
+        .readTimeout(120, TimeUnit.SECONDS)
+        .connectionSpecs(Arrays.asList(spec, ConnectionSpec.CLEARTEXT))
+        .build();
+    authenticator.setClient(client);
+    assertEquals(authenticator.getClient(), client);
 
     // Authenticator should request new, valid token.
-    requestBuilder = new Request.Builder().url("https://test.com");
+    Request.Builder requestBuilder = new Request.Builder().url("https://test.com");
     authenticator.authenticate(requestBuilder);
     verifyAuthHeader(requestBuilder, "Bearer " + tokenData.getData().getToken());
 
@@ -356,6 +371,9 @@ public class Cp4dServiceInstanceAuthenticatorTest extends BaseServiceUnitTest {
     requestBuilder = new Request.Builder().url("https://test.com");
     authenticator.authenticate(requestBuilder);
     verifyAuthHeader(requestBuilder, "Bearer " + tokenData.getData().getToken());
+
+    // Verify that the authenticator is still using the same client instance that we set before.
+    assertEquals(authenticator.getClient(), client);
   }
 
   @Test

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/IamAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/IamAuthenticatorTest.java
@@ -21,6 +21,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -44,7 +45,9 @@ import com.ibm.cloud.sdk.core.service.exception.ServiceResponseException;
 import com.ibm.cloud.sdk.core.test.BaseServiceUnitTest;
 import com.ibm.cloud.sdk.core.util.Clock;
 
+import okhttp3.ConnectionSpec;
 import okhttp3.Headers;
+import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.mockwebserver.RecordedRequest;
 
@@ -279,6 +282,19 @@ public class IamAuthenticatorTest extends BaseServiceUnitTest {
         .disableSSLVerification(true)
         .build();
 
+    // Create a custom client and set it on the authenticator.
+    ConnectionSpec spec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+        .allEnabledCipherSuites()
+        .build();
+    OkHttpClient client = new OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(120, TimeUnit.SECONDS)
+        .readTimeout(120, TimeUnit.SECONDS)
+        .connectionSpecs(Arrays.asList(spec, ConnectionSpec.CLEARTEXT))
+        .build();
+    authenticator.setClient(client);
+    assertEquals(authenticator.getClient(), client);
+
     Request.Builder requestBuilder = new Request.Builder().url("https://test.com");
 
     // Authenticator should request new, valid token.
@@ -297,6 +313,9 @@ public class IamAuthenticatorTest extends BaseServiceUnitTest {
     requestBuilder = new Request.Builder().url("https://test.com");
     authenticator.authenticate(requestBuilder);
     verifyAuthHeader(requestBuilder, "Bearer " + tokenData.getAccessToken());
+
+    // Verify that the authenticator is still using the same client instance that we set before.
+    assertEquals(authenticator.getClient(), client);
   }
 
   @Test


### PR DESCRIPTION
This commit modifies the java core so that users can now
specify a fully-configured OkHttpClient instance to be
used by service and authenticator instances:
1. The HttpClientSingleton class now has methods setHttpClient()
   and getHttpClient().  These methods can be used to set and get
   the default client configuration from which other OkHttpClient
   instances are created.
2. The TokenRequestBasedAuthenticator base class now has methods
   setClient() and getClient().  These methods can be used to set
   and get the specific OkHttpClient instance that should be used
   by an authenticator when interacting with the token service.
   These new methods are inherited by each of the request-based
   authenticator implementation classes: ContainerAuthenticator,
   CloudPakForDataAuthenticator, CloudPakForDataServiceAuthenticator,
   CloudPakForDataServiceInstanceAuthenticator, IamAuthenticator, and
   VpcInstanceAuthenticator.

Note: ~~I plan to update this PR slightly so that the HttpClientSingleton will create a default OkHttpClient instance that supports  mutual TLS (if possible).  First, I need to learn what those details are :)   The PR can be reviewed in its current state as these follow-on changes should be fairly small and isolated to the HttpClientSingleton class.~~
Upon further review, I'm going to go ahead with this PR as-is.  If additional research into the mTLS topic reveals a path where I can configure the default OkHttpClient instance such that mTLS works out of the box without affecting existing use-cases, then I will follow-up with a new PR to make those changes.