### PR TITLE
fix: Update okhttp dependency to address CVE-2021-0341

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <checkstyle-version>8.41</checkstyle-version>
         <jacoco-plugin-version>0.8.7</jacoco-plugin-version>
         <compiler-plugin-version>3.8.0</compiler-plugin-version>
-        <okhttp3-version>4.9.1</okhttp3-version>
+        <okhttp3-version>4.9.3</okhttp3-version>
         <guava-version>30.1.1-jre</guava-version>
         <gson-version>2.9.0</gson-version>
         <commons-codec-version>1.15</commons-codec-version>


### PR DESCRIPTION
See square/okhttp#6724