### PR TITLE
build: remove unnecessary cve from .cveignore

### DIFF
--- a/.cra/.cveignore
+++ b/.cra/.cveignore
@@ -1,7 +1,2 @@
 [
-    {
-        "cve": "SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744",
-        "alwaysOmit": true,
-        "comment": "The dependencies of this project that use kotlin-stdlib (the okhttp-related dependencies) do not invoke the two kotlin-stdlib vulnerable methods"
-    }
 ]


### PR DESCRIPTION
While running the cra ad-hoc report job against the java core, the resulting report stated:
![image](https://user-images.githubusercontent.com/26463020/183516134-0a8e427b-60fc-4e12-aa07-ec5f3a7a5459.png)

So, this PR removes that entry from .cra/.cveignore.