### PR TITLE
fix: use gson 'lazily parsed number' for 'object to number' strategy

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/util/GsonSingleton.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/GsonSingleton.java
@@ -47,7 +47,7 @@ public final class GsonSingleton {
    */
   private static Gson createGson(boolean prettyPrint, boolean serializeNulls) {
     GsonBuilder builder = new GsonBuilder()
-        .setObjectToNumberStrategy(ToNumberPolicy.DOUBLE)
+        .setObjectToNumberStrategy(ToNumberPolicy.LAZILY_PARSED_NUMBER)
         .setNumberToNumberStrategy(ToNumberPolicy.LAZILY_PARSED_NUMBER);
 
     registerTypeAdapters(builder);

--- a/src/test/java/com/ibm/cloud/sdk/core/util/GsonSingletonTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/GsonSingletonTest.java
@@ -21,12 +21,14 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import com.google.gson.ToNumberPolicy;
 import com.google.gson.internal.LazilyParsedNumber;
 import com.google.gson.reflect.TypeToken;
 
@@ -99,5 +101,19 @@ public class GsonSingletonTest {
     String jsonString = "{\"foo\":[\"numberlist\"]}";
     Gson gson = GsonSingleton.getGsonWithSerializeNulls();
     gson.fromJson(jsonString, modelType);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testLazilyParsedNumber4() {
+    Gson gson = GsonSingleton.getGsonWithoutPrettyPrinting();
+
+    String jsonString = "{\"foo\":38.9999,\"bar\":28.0001,\"baz\":74}";
+    Map<String, Object> map = gson.fromJson(jsonString, Map.class);
+    assertNotNull(map);
+
+    String serializedMap = gson.toJson(map);
+    assertNotNull(serializedMap);
+    assertEquals(serializedMap, jsonString);
   }
 }


### PR DESCRIPTION
This commit makes a small change to our Gson factory so that it sets the "object to number" strategy to LAZILY_PARSED_NUMBER. The default value (DOUBLE) does not provide the fidelity needed when performing marshalling/unmarshalling steps involving generic datastructures like Map<String,Object>.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>