### PR TITLE
test: transition from powermock to mockito for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <commons-io-version>2.7</commons-io-version>
         <commons-lang3-version>3.8.1</commons-lang3-version>
         <rx-version>2.2.7</rx-version>
-        <powermock-version>2.0.9</powermock-version>
+        <mockito-version>4.11.0</mockito-version>
         <maven-deploy-plugin-version>3.0.0</maven-deploy-plugin-version>
         <nexus-staging-plugin-version>1.6.13</nexus-staging-plugin-version>
         <maven-gpg-plugin-version>3.0.1</maven-gpg-plugin-version>
@@ -134,15 +134,15 @@
             <version>${rx-version}</version>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock-version}</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
-            <version>${powermock-version}</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -359,16 +359,6 @@
                 <!-- Configure the gpg plugin to use the env vars defined in the Travis build settings -->
                 <gpg.keyname>${env.GPG_KEYNAME}</gpg.keyname>
                 <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
-            </properties>
-        </profile>
-        <profile>
-            <id>java16+</id>
-            <activation>
-                <jdk>[16,)</jdk>
-            </activation>
-            <properties>
-                <!-- For java 16 and higher, we need these jvm args when running tests due to errors caused by other libraries. -->
-                <surefireJvmArgs>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.logging/java.util.logging=ALL-UNNAMED</surefireJvmArgs>
             </properties>
         </profile>
     </profiles>

--- a/src/test/java/com/ibm/cloud/sdk/core/test/BaseServiceUnitTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/BaseServiceUnitTest.java
@@ -26,7 +26,6 @@ import okhttp3.mockwebserver.RecordedRequest;
 
 import org.apache.commons.lang3.StringUtils;
 import org.testng.annotations.AfterMethod;
-import org.powermock.modules.testng.PowerMockTestCase;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -39,7 +38,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-public class BaseServiceUnitTest extends PowerMockTestCase {
+public class BaseServiceUnitTest /* extends PowerMockTestCase */ {
   private static final Gson GSON = GsonSingleton.getGson();
 
   /** The server. */

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/ConfigBasedAuthenticatorFactoryTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/ConfigBasedAuthenticatorFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2015, 2021.
+ * (C) Copyright IBM Corp. 2015, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -24,10 +24,11 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.powermock.modules.testng.PowerMockTestCase;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import com.ibm.cloud.sdk.core.security.Authenticator;
 import com.ibm.cloud.sdk.core.security.CloudPakForDataServiceAuthenticator;
@@ -42,8 +43,7 @@ import com.ibm.cloud.sdk.core.util.EnvironmentUtils;
  * This class tests the ConfigBasedAuthenticatorFactory class.
  * We'll using various mocking techniques to simulate the credential file, environment and vcap services.
  */
-@PrepareForTest({ EnvironmentUtils.class })
-public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
+public class ConfigBasedAuthenticatorFactoryTest {
   private static final String ALTERNATE_CRED_FILENAME = "src/test/resources/my-credentials.env";
   private static final String VCAP_SERVICES = "vcap_services.json";
 
@@ -113,6 +113,22 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
     return env;
   }
 
+  // This will be our mocked version of the EnvironmentUtils class.
+  private static MockedStatic<EnvironmentUtils> envMock = null;
+
+  @BeforeMethod
+  public void createEnvMock() {
+    envMock = Mockito.mockStatic(EnvironmentUtils.class);
+  }
+
+  @AfterMethod
+  public void clearEnvMock() {
+    if (envMock != null) {
+      envMock.close();
+      envMock = null;
+    }
+  }
+
   /**
    * Sets up a mock VCAP_SERVICES object.
    */
@@ -120,14 +136,12 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
     final InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(VCAP_SERVICES);
     final String vcapServices = getStringFromInputStream(in);
 
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("VCAP_SERVICES")).thenReturn(vcapServices);
+    envMock.when(() ->EnvironmentUtils.getenv("VCAP_SERVICES")).thenReturn(vcapServices);
   }
 
   @Test
   public void testNoConfig() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(null);
+    envMock.when(() ->EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(null);
 
     Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service-1");
     assertNull(auth);
@@ -163,8 +177,7 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsService1() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() ->EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
     assertEquals(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE"), ALTERNATE_CRED_FILENAME);
 
     Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service-1");
@@ -174,8 +187,7 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsService2() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() ->EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
 
     Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service2");
     assertNotNull(auth);
@@ -184,8 +196,7 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsService3() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() ->EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
 
     Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service3");
     assertNotNull(auth);
@@ -194,8 +205,7 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsService4() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() ->EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
 
     Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service4");
     assertNotNull(auth);
@@ -204,8 +214,7 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsService11() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() ->EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
 
     Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service_11");
     assertNotNull(auth);
@@ -223,8 +232,7 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsService12() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() ->EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
 
     Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service_12");
     assertNotNull(auth);
@@ -242,8 +250,7 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsService13() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() ->EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
 
     Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service_13");
     assertNotNull(auth);
@@ -261,8 +268,7 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsService15() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() ->EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
 
     Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service_15");
     assertNotNull(auth);
@@ -275,8 +281,7 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsService16() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() ->EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
 
     Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service_16");
     assertNotNull(auth);
@@ -289,8 +294,7 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsService5() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() ->EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
 
     Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service5");
     assertNotNull(auth);
@@ -299,32 +303,28 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testFileCredentialsError1() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() ->EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
 
     ConfigBasedAuthenticatorFactory.getAuthenticator("error1");
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testFileCredentialsError2() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() ->EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
 
     ConfigBasedAuthenticatorFactory.getAuthenticator("error2");
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testFileCredentialsError3() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() ->EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
 
     ConfigBasedAuthenticatorFactory.getAuthenticator("error3");
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testFileCredentialsError4() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() ->EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
 
     ConfigBasedAuthenticatorFactory.getAuthenticator("error4");
   }
@@ -342,8 +342,7 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test
   public void testEnvCredentialsService1() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() ->EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service-1");
     assertNotNull(auth);
@@ -358,8 +357,7 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test
   public void testEnvCredentialsService6() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() ->EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service6");
     assertNotNull(auth);
@@ -372,8 +370,7 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test
   public void testEnvCredentialsService7() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() ->EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service7");
     assertNotNull(auth);
@@ -391,8 +388,7 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test
   public void testEnvCredentialsService8() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() ->EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service8");
     assertNotNull(auth);
@@ -405,8 +401,7 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test
   public void testEnvCredentialsService9() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() ->EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     Authenticator auth = ConfigBasedAuthenticatorFactory.getAuthenticator("service9");
     assertNotNull(auth);
@@ -421,16 +416,14 @@ public class ConfigBasedAuthenticatorFactoryTest extends PowerMockTestCase {
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testEnvCredentialsError1() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() ->EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     ConfigBasedAuthenticatorFactory.getAuthenticator("error1");
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testEnvCredentialsError2() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() ->EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     ConfigBasedAuthenticatorFactory.getAuthenticator("error2");
   }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dServiceAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dServiceAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2022, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -26,9 +26,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -45,12 +45,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.mockwebserver.RecordedRequest;
 
-@PrepareForTest({ Clock.class })
-@PowerMockIgnore({
-    "javax.net.ssl.*",
-    "okhttp3.*",
-    "okio.*"
-})
 public class Cp4dServiceAuthenticatorTest extends BaseServiceUnitTest {
 
   // Token with issued-at time of 1574353085 and expiration time of 1574453956
@@ -74,6 +68,22 @@ public class Cp4dServiceAuthenticatorTest extends BaseServiceUnitTest {
     url = getMockWebServerUrl();
     tokenData = loadFixture("src/test/resources/cp4d_token.json", Cp4dTokenResponse.class);
     refreshedTokenData = loadFixture("src/test/resources/refreshed_cp4d_token.json", Cp4dTokenResponse.class);
+  }
+
+  // This will be our mocked version of the Clock class.
+  private static MockedStatic<Clock> clockMock = null;
+
+  @BeforeMethod
+  public void createEnvMock() {
+    clockMock = Mockito.mockStatic(Clock.class);
+  }
+
+  @AfterMethod
+  public void clearEnvMock() {
+    if (clockMock != null) {
+      clockMock.close();
+      clockMock = null;
+    }
   }
 
   //
@@ -429,8 +439,7 @@ public class Cp4dServiceAuthenticatorTest extends BaseServiceUnitTest {
     server.enqueue(jsonResponse(tokenData));
 
     // Mock current time to ensure that we're way before the token expiration time.
-    PowerMockito.mockStatic(Clock.class);
-    PowerMockito.when(Clock.getCurrentTimeInSeconds()).thenReturn((long) 100);
+    clockMock.when(() -> Clock.getCurrentTimeInSeconds()).thenReturn((long) 100);
 
     CloudPakForDataServiceAuthenticator authenticator = new CloudPakForDataServiceAuthenticator.Builder()
         .url(url)
@@ -475,8 +484,7 @@ public class Cp4dServiceAuthenticatorTest extends BaseServiceUnitTest {
     server.enqueue(jsonResponse(tokenData));
 
     // Mock current time to ensure that we've passed the token expiration time.
-    PowerMockito.mockStatic(Clock.class);
-    PowerMockito.when(Clock.getCurrentTimeInSeconds()).thenReturn((long) 1800000000);
+    clockMock.when(() -> Clock.getCurrentTimeInSeconds()).thenReturn((long) 1800000000);
 
     CloudPakForDataServiceAuthenticator authenticator = new CloudPakForDataServiceAuthenticator.Builder()
         .url(url)
@@ -502,8 +510,7 @@ public class Cp4dServiceAuthenticatorTest extends BaseServiceUnitTest {
     server.enqueue(jsonResponse(tokenData));
 
     // Mock current time to put us in the "refresh window" where the token is not expired but still needs refreshed.
-    PowerMockito.mockStatic(Clock.class);
-    PowerMockito.when(Clock.getCurrentTimeInSeconds()).thenReturn((long) 1574453700);
+    clockMock.when(() -> Clock.getCurrentTimeInSeconds()).thenReturn((long) 1574453700);
 
     CloudPakForDataServiceAuthenticator authenticator = new CloudPakForDataServiceAuthenticator.Builder()
         .url(url)
@@ -540,8 +547,7 @@ public class Cp4dServiceAuthenticatorTest extends BaseServiceUnitTest {
     server.enqueue(jsonResponse(tokenData));
 
     // Mock current time to ensure the token is valid.
-    PowerMockito.mockStatic(Clock.class);
-    PowerMockito.when(Clock.getCurrentTimeInSeconds()).thenReturn((long) 100);
+    clockMock.when(() -> Clock.getCurrentTimeInSeconds()).thenReturn((long) 100);
 
     CloudPakForDataServiceAuthenticator authenticator = new CloudPakForDataServiceAuthenticator.Builder()
         .url(url)
@@ -582,8 +588,7 @@ public class Cp4dServiceAuthenticatorTest extends BaseServiceUnitTest {
     server.enqueue(errorResponse(400));
 
     // Mock current time to ensure the token is valid.
-    PowerMockito.mockStatic(Clock.class);
-    PowerMockito.when(Clock.getCurrentTimeInSeconds()).thenReturn((long) 100);
+    clockMock.when(() -> Clock.getCurrentTimeInSeconds()).thenReturn((long) 100);
 
     CloudPakForDataServiceAuthenticator authenticator = new CloudPakForDataServiceAuthenticator.Builder()
         .url(url)
@@ -601,8 +606,7 @@ public class Cp4dServiceAuthenticatorTest extends BaseServiceUnitTest {
     server.enqueue(jsonResponse("{'}"));
 
     // Mock current time to ensure the token is valid.
-    PowerMockito.mockStatic(Clock.class);
-    PowerMockito.when(Clock.getCurrentTimeInSeconds()).thenReturn((long) 100);
+    clockMock.when(() -> Clock.getCurrentTimeInSeconds()).thenReturn((long) 100);
 
     CloudPakForDataServiceAuthenticator authenticator = new CloudPakForDataServiceAuthenticator.Builder()
         .url(url)

--- a/src/test/java/com/ibm/cloud/sdk/core/util/CredentialUtilsTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/CredentialUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2015, 2019.
+ * (C) Copyright IBM Corp. 2015, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -16,18 +16,19 @@ package com.ibm.cloud.sdk.core.util;
 import static com.ibm.cloud.sdk.core.test.TestUtils.getStringFromInputStream;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.assertNotNull;
 
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.powermock.modules.testng.PowerMockTestCase;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import com.ibm.cloud.sdk.core.security.Authenticator;
 import com.ibm.cloud.sdk.core.security.CloudPakForDataAuthenticator;
@@ -36,12 +37,27 @@ import com.ibm.cloud.sdk.core.service.BaseService;
 /**
  * The Class CredentialUtilsTest.
  */
-@PrepareForTest({ EnvironmentUtils.class })
-public class CredentialUtilsTest extends PowerMockTestCase {
+public class CredentialUtilsTest {
   private static final String ALTERNATE_CRED_FILENAME = "src/test/resources/my-credentials.env";
   private static final String VCAP_SERVICES = "vcap_services.json";
   private static final String NOT_A_USERNAME = "not-a-username";
   private static final String NOT_A_PASSWORD = "not-a-password";
+
+  // This will be our mocked version of the EnvironmentUtils class.
+  private static MockedStatic<EnvironmentUtils> envMock = null;
+
+  @BeforeMethod
+  public void createEnvMock() {
+    envMock = Mockito.mockStatic(EnvironmentUtils.class);
+  }
+
+  @AfterMethod
+  public void clearEnvMock() {
+    if (envMock != null) {
+      envMock.close();
+      envMock = null;
+    }
+  }
 
   private Map<String, String> getTestProcessEnvironment() {
     Map<String, String> env = new HashMap<>();
@@ -195,12 +211,11 @@ public class CredentialUtilsTest extends PowerMockTestCase {
   /**
    * Setup.
    */
-  public void setupVCAP() {
+  private void setupVCAP() {
     final InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(VCAP_SERVICES);
     final String vcapServices = getStringFromInputStream(in);
 
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("VCAP_SERVICES")).thenReturn(vcapServices);
+    envMock.when(() -> EnvironmentUtils.getenv("VCAP_SERVICES")).thenReturn(vcapServices);
   }
 
   @Test
@@ -246,16 +261,14 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsMapEmpty() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(null);
+    envMock.when(() -> EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(null);
     Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service-1");
     assertTrue(props.isEmpty());
   }
 
   @Test
   public void testFileCredentialsMapService1() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() -> EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
     assertEquals(ALTERNATE_CRED_FILENAME, EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE"));
 
     Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service-1");
@@ -264,8 +277,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsMapService2() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() -> EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
     assertEquals(ALTERNATE_CRED_FILENAME, EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE"));
 
     Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service2");
@@ -274,8 +286,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsMapService3() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() -> EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
     assertEquals(ALTERNATE_CRED_FILENAME, EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE"));
 
     Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service3");
@@ -284,8 +295,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsMapService4() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() -> EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
     assertEquals(ALTERNATE_CRED_FILENAME, EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE"));
 
     Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service4");
@@ -294,8 +304,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsMapService5() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() -> EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
     assertEquals(ALTERNATE_CRED_FILENAME, EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE"));
 
     Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service5");
@@ -304,8 +313,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsMapService6() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() -> EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
     assertEquals(ALTERNATE_CRED_FILENAME, EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE"));
 
     Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service6");
@@ -314,8 +322,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsMapService7() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() -> EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
     assertEquals(ALTERNATE_CRED_FILENAME, EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE"));
 
     Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service-7");
@@ -324,8 +331,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsMapService8() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() -> EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
     assertEquals(ALTERNATE_CRED_FILENAME, EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE"));
 
     Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service-8");
@@ -334,8 +340,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testFileCredentialsMapService9() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
+    envMock.when(() -> EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(ALTERNATE_CRED_FILENAME);
     assertEquals(ALTERNATE_CRED_FILENAME, EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE"));
 
     Map<String, String> props = CredentialUtils.getFileCredentialsAsMap("service-9");
@@ -463,16 +468,14 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testEnvCredentialsMapEmpty() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(new HashMap<String, String>());
+    envMock.when(() -> EnvironmentUtils.getenv()).thenReturn(new HashMap<String, String>());
     Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service-1");
     assertTrue(props.isEmpty());
   }
 
   @Test
   public void testEnvCredentialsMapService1() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() -> EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service-1");
     verifyMapService1(props);
@@ -480,8 +483,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testEnvCredentialsMapService2() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() -> EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service2");
     verifyMapService2(props);
@@ -489,8 +491,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testEnvCredentialsMapService3() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() -> EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service3");
     verifyMapService3(props);
@@ -498,8 +499,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testEnvCredentialsMapService4() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() -> EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service4");
     verifyMapService4(props);
@@ -507,8 +507,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testEnvCredentialsMapService5() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() -> EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service5");
     verifyMapService5(props);
@@ -516,8 +515,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testEnvCredentialsMapService6() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() -> EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service6");
     verifyMapService6(props);
@@ -525,8 +523,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testEnvCredentialsMapService7() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() -> EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service-7");
     verifyMapService7(props);
@@ -534,8 +531,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testEnvCredentialsMapService8() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() -> EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service-8");
     verifyMapService8(props);
@@ -543,8 +539,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testEnvCredentialsMapService9() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() -> EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service-9");
     verifyMapService9(props);
@@ -552,8 +547,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
 
   @Test
   public void testEnvCredentialsMapService14() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() -> EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
 
     Map<String, String> props = CredentialUtils.getEnvCredentialsAsMap("service-14");
     verifyMapService14(props);
@@ -565,8 +559,7 @@ public class CredentialUtilsTest extends PowerMockTestCase {
     assertTrue(props.isEmpty());
 
     // Setting Only environment variables should still result in empty props
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    envMock.when(() -> EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
     props = CredentialUtils.getSystemPropsCredentialsAsMap("service-1");
     assertTrue(props.isEmpty());
   }


### PR DESCRIPTION
This commit modifies the project so that the mockito library is used for mocking within testcases instead of powermock.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>