### PR TITLE
build: java 11 min jdk for build/test

### DIFF
--- a/.cra/.cveignore
+++ b/.cra/.cveignore
@@ -1,7 +1,2 @@
 [
-    {
-        "cve": "SNYK-JAVA-ORGTESTNG-3040285",
-        "alwaysOmit": true,
-        "comment": "The 'Zip Slip' vulnerability does not apply to this project because we merely use TestNG to execute testcases during our maven build, and we do not deliver a jar containing test classes."
-    }
 ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-10-04T19:46:37Z",
+  "generated_at": "2023-01-15T20:44:19Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -140,7 +140,7 @@
         "hashed_secret": "360c23c1ac7d9d6dad1d0710606b0df9de6e1a18",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 71,
+        "line_number": 65,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -150,7 +150,7 @@
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 66,
+        "line_number": 60,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -158,7 +158,7 @@
         "hashed_secret": "2207d3f3ac68743290fe4affc71c10bec4962232",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 67,
+        "line_number": 61,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -168,7 +168,7 @@
         "hashed_secret": "ca3f35fa1a5cb92b242c2b42d6d902d43b4816f0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 64,
+        "line_number": 58,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -178,7 +178,7 @@
         "hashed_secret": "2207d3f3ac68743290fe4affc71c10bec4962232",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 64,
+        "line_number": 58,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -206,7 +206,7 @@
         "hashed_secret": "028b5586cf1cd56839aa65b4546373e12fb60396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 706,
+        "line_number": 699,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -352,7 +352,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.52.dss",
+  "version": "0.13.1+ibm.56.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 ---
 language: java
-dist: bionic
+dist: jammy
 
 jdk:
-- openjdk8
+- openjdk11
 
 notifications:
   email: true
@@ -35,15 +35,10 @@ before_install:
 jobs:
   include:
     - stage: Build-Test
-      jdk: openjdk8
+      jdk: openjdk11
       install: skip
       script:
         - build/setMavenVersion.sh
-        - mvn clean package $MVN_ARGS
-
-    - jdk: openjdk11
-      install: skip
-      script:
         - mvn clean package $MVN_ARGS
 
     - jdk: openjdk17
@@ -52,7 +47,7 @@ jobs:
         - mvn clean package $MVN_ARGS
 
     - stage: Semantic-Release
-      jdk: openjdk8
+      jdk: openjdk11
       install:
         - nvm install 14
         - npm install
@@ -63,7 +58,7 @@ jobs:
         - echo "Semantic release has successfully created a new tagged-release"
 
     - stage: Publish-Release
-      jdk: openjdk8
+      jdk: openjdk11
       name: Publish-Javadoc
       install: true
       script:
@@ -73,7 +68,7 @@ jobs:
       after_success:
         - echo "Javadocs successfully published to gh-pages!"
 
-    - jdk: openjdk8
+    - jdk: openjdk11
       name: Publish-To-Maven-Central
       install: true
       script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Here are some examples of acceptable commit messages, along with the release typ
 If you want to contribute to the repository, here's a quick guide:
   1. Fork the repository
   2. Develop and test your code changes:
-      * To build/test: `mvn clean package`
+      * To build/test: `mvn clean package` (Java 11+ is required when building the project)
       * Please add one or more tests to validate your changes.
   3. Make sure everything builds/tests cleanly
   4. Commit your changes  

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <testng-version>7.4.0</testng-version>
+        <testng-version>7.7.1</testng-version>
+        <testng-slf4j-version>2.0.6</testng-slf4j-version>
         <surefire-version>3.0.0-M7</surefire-version>
         <checkstyle-plugin-version>3.2.0</checkstyle-plugin-version>
         <checkstyle-version>8.41</checkstyle-version>
@@ -27,6 +28,13 @@
         <maven-deploy-plugin-version>3.0.0</maven-deploy-plugin-version>
         <nexus-staging-plugin-version>1.6.13</nexus-staging-plugin-version>
         <maven-gpg-plugin-version>3.0.1</maven-gpg-plugin-version>
+        
+        <maven-enforcer-version>3.1.0</maven-enforcer-version>
+        <min-jdk-version>11</min-jdk-version>
+        <min-maven-version>3.5.0</min-maven-version>
+
+        <java-source-version>1.8</java-source-version>
+        <java-target-version>1.8</java-target-version>
 
         <!-- versions of transitive dependencies we need to override to avoid vulnerability alerts -->
         <junit-version>4.13.2</junit-version>
@@ -119,6 +127,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${testng-slf4j-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${testng-slf4j-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava-version}</version>
@@ -159,6 +179,31 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven-enforcer-version}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>${min-maven-version}</version>
+                                    <message>Apache Maven ${min-maven-version}+ is required to build this project.</message>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>${min-jdk-version}</version>
+                                    <message>Java ${min-jdk-version}+ is required to build this project.</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <!-- Disable default maven-deploy-plugin -->
                 <groupId>org.apache.maven.plugins</groupId>
@@ -268,8 +313,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin-version}</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${java-source-version}</source>
+                    <target>${java-target-version}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/com/ibm/cloud/sdk/core/test/http/ratelimit/RateLimitTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/http/ratelimit/RateLimitTest.java
@@ -16,26 +16,25 @@ import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static com.ibm.cloud.sdk.core.http.HttpHeaders.CONTENT_TYPE;
 import static com.ibm.cloud.sdk.core.http.HttpHeaders.CONTENT_ENCODING;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNotNull;
 
 public class RateLimitTest extends BaseServiceUnitTest {
 
     public class TestModel extends GenericModel {
         String success;
-
         public String getSuccess() {
             return success;
         }
     }
-
 
     public class TestService extends BaseService {
 
@@ -58,6 +57,7 @@ public class RateLimitTest extends BaseServiceUnitTest {
      *
      * @see com.ibm.cloud.sdk.core.test.WatsonServiceTest#setUp()
      */
+    @SuppressWarnings("deprecation")
     @Override
     @BeforeMethod
     public void setUp() throws Exception {
@@ -88,9 +88,9 @@ public class RateLimitTest extends BaseServiceUnitTest {
         } catch (Exception e) {
             assertTrue(e instanceof TooManyRequestsException);
             TooManyRequestsException ex = (TooManyRequestsException) e;
-            assertEquals(429, ex.getStatusCode());
+            assertEquals(ex.getStatusCode(), 429);
             assertEquals(message, ex.getMessage());
-            assertEquals(4, server.getRequestCount());
+            assertEquals(server.getRequestCount(), 4);
         }
     }
 
@@ -111,12 +111,11 @@ public class RateLimitTest extends BaseServiceUnitTest {
                 .addHeader(CONTENT_TYPE, HttpMediaType.APPLICATION_JSON)
                 .setBody("{\"success\": \"awesome\"}"));
 
-
         Response<TestModel> r = service.testMethod().execute();
 
-        assertEquals(200, r.getStatusCode());
-        assertEquals("awesome", r.getResult().getSuccess());
-        assertEquals(2, server.getRequestCount());
+        assertEquals(r.getStatusCode(), 200);
+        assertEquals(r.getResult().getSuccess(), "awesome");
+        assertEquals(server.getRequestCount(), 2);
 
         RecordedRequest request = server.takeRequest();
         assertNotNull(request);
@@ -143,9 +142,8 @@ public class RateLimitTest extends BaseServiceUnitTest {
 
         Response<TestModel> r = service.testMethod().execute();
 
-        assertEquals(200, r.getStatusCode());
-        assertEquals("awesome", r.getResult().getSuccess());
-        assertEquals(2, server.getRequestCount());
-
+        assertEquals(r.getStatusCode(), 200);
+        assertEquals(r.getResult().getSuccess(), "awesome");
+        assertEquals(server.getRequestCount(), 2);
     }
 }

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dServiceInstanceAuthenticatorLiveTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dServiceInstanceAuthenticatorLiveTest.java
@@ -16,8 +16,8 @@ package com.ibm.cloud.sdk.core.test.security;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.testng.annotations.Ignore;
+import org.testng.annotations.Test;
 
 import com.ibm.cloud.sdk.core.http.HttpHeaders;
 import com.ibm.cloud.sdk.core.security.Authenticator;


### PR DESCRIPTION
This commit modifies the project so that we now require java 11 for build/test.  We still produce java8-compatible classes, but we require java 11+ for building/testing due to dependency requirements.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>