### PR TITLE
refactor: remove guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
         <jacoco-plugin-version>0.8.8</jacoco-plugin-version>
         <compiler-plugin-version>3.10.1</compiler-plugin-version>
         <okhttp3-version>4.10.0</okhttp3-version>
-        <guava-version>30.1.1-jre</guava-version>
         <gson-version>2.9.1</gson-version>
         <commons-codec-version>1.15</commons-codec-version>
         <commons-io-version>2.7</commons-io-version>
@@ -137,11 +136,6 @@
             <artifactId>slf4j-simple</artifactId>
             <version>${testng-slf4j-version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava-version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/com/ibm/cloud/sdk/core/security/AuthenticatorBase.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/AuthenticatorBase.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019, 2021.
+ * (C) Copyright IBM Corp. 2019, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,9 +13,8 @@
 
 package com.ibm.cloud.sdk.core.security;
 
+import java.util.Base64;
 import org.apache.commons.lang3.StringUtils;
-
-import com.google.common.io.BaseEncoding;
 
 /**
  * This is a common base class used with the various Authenticator implementations.
@@ -42,7 +41,7 @@ public class AuthenticatorBase {
    */
   public static String constructBasicAuthHeader(String username, String password) {
     if (StringUtils.isNotEmpty(username) && StringUtils.isNotEmpty(password)) {
-      return "Basic " + BaseEncoding.base64().encode(((username + ":" + password).getBytes()));
+      return "Basic " + Base64.getEncoder().encodeToString(((username + ":" + password).getBytes()));
     }
     return null;
   }

--- a/src/main/java/com/ibm/cloud/sdk/core/security/JsonWebToken.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/JsonWebToken.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019.
+ * (C) Copyright IBM Corp. 2019, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,12 +13,13 @@
 
 package com.ibm.cloud.sdk.core.security;
 
-import com.google.common.io.BaseEncoding;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import com.ibm.cloud.sdk.core.util.GsonSingleton;
 
 import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+import java.util.Base64;
 import java.util.Map;
 
 /**
@@ -41,11 +42,11 @@ public class JsonWebToken {
     Type headerType = new TypeToken<Map<String, String>>(){}.getType();
 
     // Decode and parse the header.
-    json = new String(BaseEncoding.base64Url().decode(decodedParts[0]));
+    json = new String(Base64.getUrlDecoder().decode(decodedParts[0]), Charset.forName("UTF-8"));
     header = GsonSingleton.getGson().fromJson(json, headerType);
 
     // Decode and parse the body.
-    json = new String(BaseEncoding.base64Url().decode(decodedParts[1]));
+    json = new String(Base64.getUrlDecoder().decode(decodedParts[1]), Charset.forName("UTF-8"));
     payload = GsonSingleton.getGson().fromJson(json, Payload.class);
   }
 

--- a/src/test/java/com/ibm/cloud/sdk/core/test/http/HttpConfigTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/http/HttpConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2015, 2022.
+ * (C) Copyright IBM Corp. 2015, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -21,8 +21,6 @@ import static org.testng.Assert.assertTrue;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
-
-import javax.annotation.Nullable;
 
 import org.testng.annotations.Test;
 
@@ -46,9 +44,8 @@ public class HttpConfigTest {
   @Test
   public void testHttpConfigOptions() {
     Authenticator authenticator = new Authenticator() {
-      @Nullable
       @Override
-      public Request authenticate(@Nullable Route route, Response response) throws IOException {
+      public Request authenticate(Route route, Response response) throws IOException {
         return null;
       }
     };

--- a/src/test/java/com/ibm/cloud/sdk/core/test/model/DynamicModelSerializationTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/model/DynamicModelSerializationTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2015, 2020.
+ * (C) Copyright IBM Corp. 2015, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,7 +13,6 @@
 
 package com.ibm.cloud.sdk.core.test.model;
 
-import com.google.common.collect.Sets;
 import com.google.gson.JsonSyntaxException;
 import com.ibm.cloud.sdk.core.service.model.DynamicModel;
 import com.ibm.cloud.sdk.core.test.model.generated.Foo;
@@ -28,8 +27,9 @@ import com.ibm.cloud.sdk.core.test.model.generated.ModelAPProtectedCtor;
 import com.ibm.cloud.sdk.core.test.model.generated.ModelAPString;
 import com.ibm.cloud.sdk.core.util.GsonSingleton;
 import org.testng.annotations.Test;
-
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
@@ -355,12 +355,12 @@ public class DynamicModelSerializationTest {
     // This test will exercise some of the DynamicModel methods
     // dealing with additional properties.
     ModelAPFoo model = createModelAPFoo();
-    assertEquals(model.getPropertyNames(), Sets.newHashSet("baseball", "football"));
+    assertEquals(model.getPropertyNames(), new HashSet<>(Arrays.asList("baseball", "football")));
 
     Foo foo = model.get("baseball");
     assertNotNull(foo);
     model.put("baseball2", foo);
-    assertEquals(model.getPropertyNames(), Sets.newHashSet("baseball", "football", "baseball2"));
+    assertEquals(model.getPropertyNames(), new HashSet<>(Arrays.asList("baseball", "football", "baseball2")));
 
     Foo newFoo = createFoo("1B", 44);
     Foo previous = model.put("baseball", newFoo);
@@ -372,7 +372,7 @@ public class DynamicModelSerializationTest {
     assertEquals(props.size(), 3);
 
     model.removeProperty("baseball2");
-    assertEquals(model.getPropertyNames(), Sets.newHashSet("baseball", "football"));
+    assertEquals(model.getPropertyNames(), new HashSet<>(Arrays.asList("baseball", "football")));
 
     ModelAPFoo newModel = deserialize(serialize(model), ModelAPFoo.class);
     assertEquals(newModel, model);
@@ -380,9 +380,9 @@ public class DynamicModelSerializationTest {
     Map<String, Foo> newProps = new HashMap<>();
     newProps.put("soccer", newFoo);
     model.setProperties(newProps);
-    assertEquals(model.getPropertyNames(), Sets.newHashSet("soccer"));
+    assertEquals(model.getPropertyNames(), new HashSet<>(Arrays.asList("soccer")));
     newProps.remove("soccer");
-    assertEquals(model.getPropertyNames(), Sets.newHashSet("soccer"));
+    assertEquals(model.getPropertyNames(), new HashSet<>(Arrays.asList("soccer")));
 
     assertTrue(model.equals(model));
     assertFalse(model.equals(null));

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/BasicAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/BasicAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2015, 2022.
+ * (C) Copyright IBM Corp. 2015, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,7 +13,6 @@
 
 package com.ibm.cloud.sdk.core.test.security;
 
-import com.google.common.io.BaseEncoding;
 import com.ibm.cloud.sdk.core.http.HttpHeaders;
 import com.ibm.cloud.sdk.core.security.Authenticator;
 import com.ibm.cloud.sdk.core.security.BasicAuthenticator;
@@ -23,7 +22,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +49,7 @@ public class BasicAuthenticatorTest {
 
     String authHeader = request.header(HttpHeaders.AUTHORIZATION);
     assertNotNull(authHeader);
-    assertEquals("Basic " + BaseEncoding.base64().encode((username + ":" + password).getBytes()), authHeader);
+    assertEquals("Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes()), authHeader);
   }
 
 

--- a/src/test/java/com/ibm/cloud/sdk/core/util/RequestUtilsTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/RequestUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2015, 2022.
+ * (C) Copyright IBM Corp. 2015, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,7 +13,6 @@
 
 package com.ibm.cloud.sdk.core.util;
 
-import com.google.common.collect.Lists;
 import com.ibm.cloud.sdk.core.http.HttpMediaType;
 
 import org.testng.annotations.Test;
@@ -21,6 +20,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -59,12 +59,12 @@ public class RequestUtilsTest {
 
     Map<String, Object> omitted = RequestUtils.omit(params, "A");
 
-    assertTrue(omitted.keySet().containsAll(Lists.newArrayList("B", "C", "D")));
-    assertTrue(omitted.values().containsAll(Lists.newArrayList(2, 3, 4)));
+    assertTrue(omitted.keySet().containsAll(Arrays.asList("B", "C", "D")));
+    assertTrue(omitted.values().containsAll(Arrays.asList(2, 3, 4)));
 
     omitted = RequestUtils.omit(params, "F");
-    assertTrue(omitted.keySet().containsAll(Lists.newArrayList("A", "B", "C", "D")));
-    assertTrue(omitted.values().containsAll(Lists.newArrayList(1, 2, 3, 4)));
+    assertTrue(omitted.keySet().containsAll(Arrays.asList("A", "B", "C", "D")));
+    assertTrue(omitted.values().containsAll(Arrays.asList(1, 2, 3, 4)));
   }
 
   /**


### PR DESCRIPTION
The guava dependency is large and causes [CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908) to get flagged by some scanning tools (though to be clear the vulnerable guava method is not used in this code).
Since guava is used in just a few places it could be removed to reduce the size of the SDKs and prevent this false positive vulnerability warning.

This PR:
* Removes `guava-version` and the guava dependency block from the pom
* Updates `RequestBuilder` to use okhttp's path segment encoding instead of guava's URL escaper
* Replaces guava base64 encoding/decoding with `java.util.Base64`
* Replaces some list/set initialization in test classes.
* Finally, removes `javax.annotation.Nullable` (as supplied by the guava package) that was referenced by `HttpConfigTest`
