### PR TITLE
fix: recognize content types with whitespace

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/service/BaseService.java
@@ -86,9 +86,9 @@ public abstract class BaseService {
 
   // Regular expression for JSON-related mimetypes.
   protected static final Pattern JSON_MIME_PATTERN =
-    Pattern.compile("(?i)application\\/((json)|(merge\\-patch\\+json))(;.*)?");
+    Pattern.compile("(?i)application\\/((json)|(merge\\-patch\\+json))(\\s*;.*)?");
   protected static final Pattern JSON_PATCH_MIME_PATTERN =
-    Pattern.compile("(?i)application\\/json\\-patch\\+json(;.*)?");
+    Pattern.compile("(?i)application\\/json\\-patch\\+json(\\s*;.*)?");
 
   // Hide the default ctor to prevent clients from calling it directly.
   protected BaseService() {

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/BaseServiceTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/BaseServiceTest.java
@@ -81,6 +81,7 @@ public class BaseServiceTest {
     assertFalse(BaseService.isJsonPatchMimeType(null));
     assertTrue(BaseService.isJsonMimeType("application/json"));
     assertTrue(BaseService.isJsonMimeType("application/json; charset=utf-8"));
+    assertTrue(BaseService.isJsonMimeType("application/json ;charset=utf-8"));
     assertTrue(BaseService.isJsonMimeType("application/json;charset=utf-8"));
     assertTrue(BaseService.isJsonMimeType("APPLICATION/JSON;charset=utf-16"));
     assertFalse(BaseService.isJsonMimeType("application/notjson"));
@@ -95,6 +96,7 @@ public class BaseServiceTest {
 
     assertTrue(BaseService.isJsonPatchMimeType("application/json-patch+json"));
     assertTrue(BaseService.isJsonPatchMimeType("application/json-patch+json;charset=utf-8"));
+    assertTrue(BaseService.isJsonPatchMimeType("application/json-patch+json ; charset=utf-8"));
     assertFalse(BaseService.isJsonPatchMimeType("application/json"));
     assertFalse(BaseService.isJsonPatchMimeType("APPLICATION/JsOn; charset=utf-8"));
     assertFalse(BaseService.isJsonPatchMimeType("application/merge-patch+json"));


### PR DESCRIPTION
The RFC for content-type header format allows optional whitespace before the semicolon. Our regular expressions for recognizing various mime types do not account for this, so valid mime types may not be recognized. This commit adjusts the expression to close that gap.