### PR TITLE
feat: bump okhttp to 4.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <checkstyle-version>8.41</checkstyle-version>
         <jacoco-plugin-version>0.8.8</jacoco-plugin-version>
         <compiler-plugin-version>3.10.1</compiler-plugin-version>
-        <okhttp3-version>4.10.0</okhttp3-version>
+        <okhttp3-version>4.11.0</okhttp3-version>
         <gson-version>2.9.1</gson-version>
         <commons-codec-version>1.15</commons-codec-version>
         <commons-io-version>2.7</commons-io-version>


### PR DESCRIPTION
This PR bumps our dependency on the okhttp library to the most recent 4.x release (4.11.0).