### PR TITLE
fix(ContainerAuthenticator): add sa-token as default CR token filename

### DIFF
--- a/Authentication.md
+++ b/Authentication.md
@@ -238,7 +238,8 @@ The IAM access token is added to each outbound request in the `Authorization` he
 ### Properties
 
 - crTokenFilename: (optional) the name of the file containing the injected CR token value.
-If not specified, then `/var/run/secrets/tokens/vault-token` is used as the default value.
+If not specified, then the authenticator will first try `/var/run/secrets/tokens/vault-token`
+and then `/var/run/secrets/tokens/sa-token` as the default value (first file found is used).
 The application must have `read` permissions on the file containing the CR token value.
 
 - iamProfileName: (optional) the name of the linked trusted IAM profile to be used when obtaining the


### PR DESCRIPTION
This commit adds support for a second default CR token filename. If the user doesn't specify a CR token filename, the authenticator will first try '/var/run/secrets/tokens/vault-token', and then '/var/run/secrets/tokens/sa-token' in that order.