### PR TITLE
build: fix javadoc-related scripts

### DIFF
--- a/build/generateJavadocIndex.sh
+++ b/build/generateJavadocIndex.sh
@@ -16,9 +16,9 @@ echo '<!DOCTYPE html>
     <div class="page-header">
         <h1>IBM Cloud Java SDK Core Library Documentation</h1>
     </div>
-    <p>Javadoc by branch/release:</p>
-    <ul>
-        <li><a href="docs/latest">Latest</a></li>'
+    <p>Javadoc by release:</p>
+    <ul>'
+echo ${TRAVIS_BRANCH} | sed 's/^.*/        <li><a href="docs\/&">Latest release<\/a><\/li>/'
 ls docs | grep --invert-match index.html | sed 's/^.*/        <li><a href="docs\/&">&<\/a><\/li>/'
 echo '    </ul>
 </div>

--- a/build/publishJavadoc.sh
+++ b/build/publishJavadoc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Publish javadocs only for a tagged-release or non-PR build of main.
-if [[ -n "${TRAVIS_TAG}" || "${TRAVIS_BRANCH}" == "main" && "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
+# Publish javadocs only for a tagged-release.
+if [[ -n "${TRAVIS_TAG}" ]]; then
 
     printf "\n>>>>> Publishing javadoc for release build: repo=%s branch=%s build_num=%s job_num=%s\n" ${TRAVIS_REPO_SLUG} ${TRAVIS_BRANCH} ${TRAVIS_BUILD_NUMBER} ${TRAVIS_JOB_NUMBER} 
 


### PR DESCRIPTION
These changes are needed because Github Pages no longer supports the use of symlinks unless one is using a paid account.