### PR TITLE
fix(RequestBuilder): retain trailing slash on operation path

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/http/RequestBuilder.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/http/RequestBuilder.java
@@ -197,6 +197,13 @@ public class RequestBuilder {
         // Add the segment to the URL, noting that it will be URL encoded by okhttp
         builder.addPathSegment(paramResolvedSegment);
       }
+
+      // Due to the way in which we're handling the path segments one at a time above,
+      // if our original path string contained a trailing slash (e.g. /v1/mypath/), then we need to
+      // add "" as a path segment to ensure that the final request URL also has a trailing slash.
+      if (path.endsWith("/")) {
+          builder.addPathSegment("");
+      }
     }
 
     // Return the final HttpUrl object.

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestBuilderTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestBuilderTest.java
@@ -443,6 +443,13 @@ public class RequestBuilderTest {
   }
 
   @Test
+  public void testResolveRequestUrlPathSlash3() {
+    HttpUrl url = RequestBuilder.resolveRequestUrl("https://myserver.com", "/v1/serviceids/");
+    assertNotNull(url);
+    assertEquals("https://myserver.com/v1/serviceids/", url.toString());
+  }
+
+  @Test
   public void testResolveRequestUrlEncodedPathParams() {
     Map<String, String> pathParameters = new HashMap<String, String>() {{
       put("param_1", "param/1");

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestTest.java
@@ -41,6 +41,7 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 
 public class RequestTest extends BaseServiceUnitTest {
+  private static String OperationPath = "/v1/test/";
   private class TestModel extends GenericModel {
     String city;
 
@@ -67,7 +68,7 @@ public class RequestTest extends BaseServiceUnitTest {
 
       final JsonObject contentJson = new JsonObject();
       contentJson.addProperty("city", model.getCity());
-      RequestBuilder builder = RequestBuilder.post(HttpUrl.parse(getServiceUrl() + "/v1/test"));
+      RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(getServiceUrl(), OperationPath));
       builder.bodyJson(contentJson).build();
       return createServiceCall(builder.build(), ResponseConverterUtils.getObject(TestModel.class));
     }
@@ -118,6 +119,7 @@ public class RequestTest extends BaseServiceUnitTest {
     // Validate the next request was compressed, which should be the call to the service
     String expectedOperationBody = "{\"city\":\"Columbus\"}";
     request = server.takeRequest();
+    assertEquals(OperationPath, request.getPath());
     assertEquals("gzip", request.getHeader(CONTENT_ENCODING));
     assertFalse(expectedOperationBody == request.getBody().readUtf8());
     assertEquals(request.getMethod(), "POST");
@@ -156,6 +158,7 @@ public class RequestTest extends BaseServiceUnitTest {
     // Validate the next request was compressed, which should be the call to the service
     String expectedOperationBody = "{\"city\":\"Columbus\"}";
     request = server.takeRequest();
+    assertEquals(OperationPath, request.getPath());
     assertEquals("gzip", request.getHeader(CONTENT_ENCODING));
     assertFalse(expectedOperationBody == request.getBody().readUtf8());
 


### PR DESCRIPTION
This PR fixes RequestBuilder.resolveRequestUrl() so that it will retain a trailing slash found on an operation path when adding the path segments to form the request URL.