### PR TITLE
build: remove 'latest' link from gh-pages

### DIFF
--- a/build/publishJavadoc.sh
+++ b/build/publishJavadoc.sh
@@ -22,16 +22,6 @@ if [[ -n "${TRAVIS_TAG}" ]]; then
     printf "\n>>>>> Generating gh-pages index.html...\n"
     ../build/generateJavadocIndex.sh > index.html
 
-    # Update the 'latest' symlink to point to this branch if it's a tagged release.
-    if [ -n "$TRAVIS_TAG" ]; then
-	pushd docs
-	rm latest
-	ln -s ./${TRAVIS_TAG} latest
-	printf "\n>>>>> Updated 'docs/latest' symlink:\n"
-	ls -l latest
-	popd
-    fi
-
     printf "\n>>>>> Committing new javadoc...\n"
     git add -f .
     git commit -m "doc: latest javadoc for ${TRAVIS_BRANCH} (${TRAVIS_COMMIT})"


### PR DESCRIPTION
This commit modifies the publishJavadoc.sh script
to remove the creation of the "latest" symbolic
link.  This is being done because github no longer allows us to include symbolic links in the gh-pages branch.