### PR TITLE
build: remove obsolete jacoco config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,11 +296,6 @@
                         </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <systemPropertyVariables>
-                        <jacoco-agent.destfile>${project.build.directory}</jacoco-agent.destfile>
-                    </systemPropertyVariables>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The maven warnings were just bugging me :)

![image](https://github.com/IBM/java-sdk-core/assets/26463020/8fd6cb08-b36f-4c11-b05b-e9f4b6107e21)
