### PR TITLE
Upgrade okhttp 4.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <checkstyle-version>10.12.3</checkstyle-version>
         <jacoco-plugin-version>0.8.10</jacoco-plugin-version>
         <compiler-plugin-version>3.11.0</compiler-plugin-version>
-        <okhttp3-version>4.11.0</okhttp3-version>
+        <okhttp3-version>4.12.0</okhttp3-version>
         <gson-version>2.10.1</gson-version>
         <commons-codec-version>1.16.0</commons-codec-version>
         <commons-io-version>2.14.0</commons-io-version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,6 @@
         <junit-version>4.13.2</junit-version>
         <kotlin-version>1.9.10</kotlin-version>
 
-        <okio-version>3.5.0</okio-version>
-
         <!-- This property should be empty by default. -->
         <surefireJvmArgs></surefireJvmArgs>
     </properties>
@@ -99,11 +97,6 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-urlconnection</artifactId>
             <version>${okhttp3-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.squareup.okio</groupId>
-            <artifactId>okio</artifactId>
-            <version>${okio-version}</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>


### PR DESCRIPTION
Upgrade okhttp to 4.12.0.
Revert the okio version override since 4.12.0 has a newer dependency.