### PR TITLE
feat(ServiceResponseException): added getResponseBody() method

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-11-08T23:43:16Z",
+  "generated_at": "2024-01-24T22:23:01Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"


### PR DESCRIPTION
This commit adds the "getResponseBody" method to the ServiceResponseException class (which serves as a baseclass for all our exceptions).  This new method can be used to retrieve the entire response body that was received within an error response from a server.

Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/3841