### PR TITLE
feat: send user-agent header with auth token requests

### DIFF
--- a/src/main/java/com/ibm/cloud/sdk/core/security/CloudPakForDataAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/CloudPakForDataAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019, 2021.
+ * (C) Copyright IBM Corp. 2019, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.google.gson.annotations.SerializedName;
 import com.ibm.cloud.sdk.core.http.HttpHeaders;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
+import com.ibm.cloud.sdk.core.util.RequestUtils;
 
 /**
  * This class provides an Authenticator implementation for the "CloudPakForData" environment.
@@ -165,7 +166,8 @@ public class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
 
   // The default ctor is hidden to force the use of the non-default ctors.
   protected CloudPakForDataAuthenticator() {
-  }
+    setUserAgent(RequestUtils.buildUserAgent("cp4d-authenticator"));
+ }
 
   /**
    * Constructs a CloudPakForDataAuthenticator instance from the configuration
@@ -174,6 +176,7 @@ public class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
    * @param builder the Builder instance containing the configuration to be used
    */
   protected CloudPakForDataAuthenticator(Builder builder) {
+    this();
     this.url = builder.url;
     this.username = builder.username;
     this.password = builder.password;
@@ -212,6 +215,7 @@ public class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
    */
   @Deprecated
   public CloudPakForDataAuthenticator(String url, String username, String password) {
+    this();
     init(url, username, password, false, null);
   }
 
@@ -236,6 +240,7 @@ public class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
   @Deprecated
   public CloudPakForDataAuthenticator(String url, String username, String password,
     boolean disableSSLVerification, Map<String, String> headers) {
+    this();
     init(url, username, password, disableSSLVerification, headers);
   }
 
@@ -249,6 +254,7 @@ public class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
    */
   @Deprecated
   public CloudPakForDataAuthenticator(Map<String, String> config) {
+    this();
     this.apikey = config.get(PROPNAME_APIKEY);
     init(config.get(PROPNAME_URL), config.get(PROPNAME_USERNAME),
       config.get(PROPNAME_PASSWORD), Boolean.valueOf(config.get(PROPNAME_DISABLE_SSL)).booleanValue(), null);
@@ -365,8 +371,9 @@ public class CloudPakForDataAuthenticator extends TokenRequestBasedAuthenticator
     // Form a POST request to retrieve the access token.
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(this.url, "/v1/authorize"));
 
-    // Add the Content-Type header.
+    // Add the Content-Type and User-Agent headers.
     builder.header(HttpHeaders.CONTENT_TYPE, "application/json");
+    builder.header(HttpHeaders.USER_AGENT, getUserAgent());
 
     // Add the request body.
     CP4DRequestBody requestBody = new CP4DRequestBody(this.username, this.password, this.apikey);

--- a/src/main/java/com/ibm/cloud/sdk/core/security/CloudPakForDataServiceAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/CloudPakForDataServiceAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2021, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -18,7 +18,9 @@ import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.ibm.cloud.sdk.core.http.HttpHeaders;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
+import com.ibm.cloud.sdk.core.util.RequestUtils;
 
 /**
  * This class provides an Authenticator implementation for the "CloudPakForData" environment.
@@ -209,7 +211,8 @@ public class CloudPakForDataServiceAuthenticator extends TokenRequestBasedAuthen
 
   // The default ctor is hidden to force the use of the non-default ctors.
   protected CloudPakForDataServiceAuthenticator() {
-  }
+    setUserAgent(RequestUtils.buildUserAgent("cp4d-service-authenticator"));
+}
 
   /**
    * Constructs a CloudPakForDataServiceAuthenticator instance from the configuration
@@ -218,6 +221,7 @@ public class CloudPakForDataServiceAuthenticator extends TokenRequestBasedAuthen
    * @param builder the Builder instance containing the configuration to be used
    */
   protected CloudPakForDataServiceAuthenticator(Builder builder) {
+    this();
     this.url = builder.url;
     this.username = builder.username;
     this.displayName = builder.displayName;
@@ -355,6 +359,7 @@ public class CloudPakForDataServiceAuthenticator extends TokenRequestBasedAuthen
   public Cp4dToken requestToken() {
     // Form a GET request to retrieve the service access token.
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(this.url, SERVICE_TOKEN_URL));
+    builder.header(HttpHeaders.USER_AGENT, getUserAgent());
 
     // Add the secret header containing the zen broker secret
     builder.header("secret", this.serviceBrokerSecret);

--- a/src/main/java/com/ibm/cloud/sdk/core/security/CloudPakForDataServiceInstanceAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/CloudPakForDataServiceInstanceAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019, 2021.
+ * (C) Copyright IBM Corp. 2019, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.ibm.cloud.sdk.core.http.HttpHeaders;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
+import com.ibm.cloud.sdk.core.util.RequestUtils;
 
 /**
  * This class provides an Authenticator implementation for the "CloudPakForData" environment.
@@ -165,6 +166,7 @@ extends TokenRequestBasedAuthenticator<Cp4dToken, Cp4dServiceInstanceTokenRespon
 
   // The default ctor is hidden to force the use of the non-default ctors.
   protected CloudPakForDataServiceInstanceAuthenticator() {
+    setUserAgent(RequestUtils.buildUserAgent("cp4d-service-instance-authenticator"));
   }
 
   /**
@@ -174,6 +176,7 @@ extends TokenRequestBasedAuthenticator<Cp4dToken, Cp4dServiceInstanceTokenRespon
    * @param builder the Builder instance containing the configuration to be used
    */
   protected CloudPakForDataServiceInstanceAuthenticator(Builder builder) {
+    this();
     this.url = builder.url;
     this.username = builder.username;
     this.apikey = builder.apikey;
@@ -287,6 +290,7 @@ extends TokenRequestBasedAuthenticator<Cp4dToken, Cp4dServiceInstanceTokenRespon
     // Form a GET request to retrieve the access token.
     RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(this.url,
         "/v3/service_instances/{service_instance_id}/token", pathParams));
+    builder.header(HttpHeaders.USER_AGENT, getUserAgent());
 
     // Add the Authorization header
     builder.header(HttpHeaders.AUTHORIZATION, constructBasicAuthHeader(this.username, this.apikey));

--- a/src/main/java/com/ibm/cloud/sdk/core/security/ContainerAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/ContainerAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021, 2023.
+ * (C) Copyright IBM Corp. 2021, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.ibm.cloud.sdk.core.http.HttpHeaders;
 import com.ibm.cloud.sdk.core.http.HttpMediaType;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
+import com.ibm.cloud.sdk.core.util.RequestUtils;
 
 import okhttp3.FormBody;
 
@@ -214,7 +215,8 @@ public class ContainerAuthenticator extends IamRequestBasedAuthenticator impleme
 
   // The default ctor is hidden to force the use of the non-default ctors.
   protected ContainerAuthenticator() {
-  }
+    setUserAgent(RequestUtils.buildUserAgent("container-authenticator"));
+}
 
   /**
    * Constructs a ContainerAuthenticator instance from the configuration
@@ -223,6 +225,7 @@ public class ContainerAuthenticator extends IamRequestBasedAuthenticator impleme
    * @param builder the Builder instance containing the configuration to be used
    */
   protected ContainerAuthenticator(Builder builder) {
+    this();
     this.crTokenFilename = builder.crTokenFilename;
     this.iamProfileName = builder.iamProfileName;
     this.iamProfileId = builder.iamProfileId;
@@ -329,10 +332,11 @@ public class ContainerAuthenticator extends IamRequestBasedAuthenticator impleme
       // Form a POST request to retrieve the access token.
       RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(this.getURL(), OPERATION_PATH));
 
-      // Now add the Accept, Content-Type and (optionally) the Authorization header to the
+      // Now add the Accept, Content-Type, User-Agent and (optionally) the Authorization header to the
       // token server request.
       builder.header(HttpHeaders.ACCEPT, HttpMediaType.APPLICATION_JSON);
       builder.header(HttpHeaders.CONTENT_TYPE, HttpMediaType.APPLICATION_FORM_URLENCODED);
+      builder.header(HttpHeaders.USER_AGENT, getUserAgent());
       addAuthorizationHeader(builder);
 
       // Build the form request body.

--- a/src/main/java/com/ibm/cloud/sdk/core/security/IamAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/IamAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2015, 2021.
+ * (C) Copyright IBM Corp. 2015, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -22,6 +22,7 @@ import com.ibm.cloud.sdk.core.http.HttpHeaders;
 import com.ibm.cloud.sdk.core.http.HttpMediaType;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
 import com.ibm.cloud.sdk.core.util.CredentialUtils;
+import com.ibm.cloud.sdk.core.util.RequestUtils;
 
 import okhttp3.FormBody;
 
@@ -173,6 +174,7 @@ public class IamAuthenticator extends IamRequestBasedAuthenticator implements Au
 
   // The default ctor is hidden to force the use of the non-default ctors.
   protected IamAuthenticator() {
+    setUserAgent(RequestUtils.buildUserAgent("iam-authenticator"));
   }
 
   /**
@@ -182,6 +184,7 @@ public class IamAuthenticator extends IamRequestBasedAuthenticator implements Au
    * @param builder the Builder instance containing the configuration to be used
    */
   protected IamAuthenticator(Builder builder) {
+    this();
     this.apikey = builder.apikey;
 
     setURL(builder.url);
@@ -215,6 +218,7 @@ public class IamAuthenticator extends IamRequestBasedAuthenticator implements Au
    */
   @Deprecated
   public IamAuthenticator(String apikey) {
+    this();
     init(apikey, null, null, null, false, null, null);
   }
 
@@ -240,6 +244,7 @@ public class IamAuthenticator extends IamRequestBasedAuthenticator implements Au
   @Deprecated
   public IamAuthenticator(String apikey, String url, String clientId, String clientSecret,
     boolean disableSSLVerification, Map<String, String> headers) {
+    this();
     init(apikey, url, clientId, clientSecret, disableSSLVerification, headers, null);
   }
 
@@ -268,6 +273,7 @@ public class IamAuthenticator extends IamRequestBasedAuthenticator implements Au
   @Deprecated
   public IamAuthenticator(String apikey, String url, String clientId, String clientSecret,
     boolean disableSSLVerification, Map<String, String> headers, String scope) {
+    this();
     init(apikey, url, clientId, clientSecret, disableSSLVerification, headers, scope);
   }
 
@@ -281,6 +287,7 @@ public class IamAuthenticator extends IamRequestBasedAuthenticator implements Au
    */
   @Deprecated
   public IamAuthenticator(Map<String, String> config) {
+    this();
     String apikey = config.get(PROPNAME_APIKEY);
     if (StringUtils.isEmpty(apikey)) {
       apikey = config.get("IAM_APIKEY");
@@ -421,9 +428,11 @@ public class IamAuthenticator extends IamRequestBasedAuthenticator implements Au
     // Form a POST request to retrieve the access token.
     RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(this.getURL(), OPERATION_PATH));
 
-    // Now add the Accept, Content-Type and (optionally) the Authorization header to the token server request.
+    // Now add the Accept, Content-Type, User-Agent and (optionally) the Authorization header
+    // to the token server request.
     builder.header(HttpHeaders.ACCEPT, HttpMediaType.APPLICATION_JSON);
     builder.header(HttpHeaders.CONTENT_TYPE, HttpMediaType.APPLICATION_FORM_URLENCODED);
+    builder.header(HttpHeaders.USER_AGENT, getUserAgent());
     addAuthorizationHeader(builder);
 
     // Build the form request body.

--- a/src/main/java/com/ibm/cloud/sdk/core/security/MCSPAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/MCSPAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2023.
+ * (C) Copyright IBM Corp. 2023, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.ibm.cloud.sdk.core.http.HttpHeaders;
 import com.ibm.cloud.sdk.core.http.HttpMediaType;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
+import com.ibm.cloud.sdk.core.util.RequestUtils;
 
 /**
  * This class provides an Authenticator implementation for the Multi-Cloud Saas
@@ -155,6 +156,7 @@ public class MCSPAuthenticator extends TokenRequestBasedAuthenticator<MCSPToken,
      * The default ctor is "hidden" to force the use of the non-default ctors.
      */
     protected MCSPAuthenticator() {
+        setUserAgent(RequestUtils.buildUserAgent("mcsp-authenticator"));
     }
 
     /**
@@ -164,6 +166,7 @@ public class MCSPAuthenticator extends TokenRequestBasedAuthenticator<MCSPToken,
      * @param builder the Builder instance containing the configuration to be used
      */
     protected MCSPAuthenticator(Builder builder) {
+        this();
         this.apikey = builder.apikey;
         this.url = builder.url;
         setDisableSSLVerification(builder.disableSSLVerification);
@@ -242,6 +245,7 @@ public class MCSPAuthenticator extends TokenRequestBasedAuthenticator<MCSPToken,
         RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(this.getURL(), OPERATION_PATH));
         builder.header(HttpHeaders.ACCEPT, HttpMediaType.APPLICATION_JSON);
         builder.header(HttpHeaders.CONTENT_TYPE, HttpMediaType.APPLICATION_JSON);
+        builder.header(HttpHeaders.USER_AGENT, getUserAgent());
 
         // Build the request body.
         String requestBody = String.format("{\"apikey\":\"%s\"}", this.getApiKey());

--- a/src/main/java/com/ibm/cloud/sdk/core/security/TokenRequestBasedAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/TokenRequestBasedAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019, 2022.
+ * (C) Copyright IBM Corp. 2019, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -53,6 +53,7 @@ public abstract class TokenRequestBasedAuthenticator<T extends AbstractToken, R 
   private static final Logger logger = Logger.getLogger(TokenRequestBasedAuthenticator.class.getName());
 
   protected OkHttpClient client;
+  protected String userAgent;
 
   // Configuration properties that are common to all subclasses.
   private boolean disableSSLVerification;
@@ -85,6 +86,18 @@ public abstract class TokenRequestBasedAuthenticator<T extends AbstractToken, R 
    */
   public OkHttpClient getClient() {
     return this.client;
+  }
+
+  /**
+   * Sets the User-Agent header value to be included in each outbound token request.
+   * @param userAgent
+   */
+  protected void setUserAgent(String userAgent) {
+    this.userAgent = userAgent;
+  }
+
+  protected String getUserAgent() {
+    return this.userAgent;
   }
 
   /**

--- a/src/main/java/com/ibm/cloud/sdk/core/security/VpcInstanceAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/VpcInstanceAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021, 2023.
+ * (C) Copyright IBM Corp. 2021, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.ibm.cloud.sdk.core.http.HttpHeaders;
 import com.ibm.cloud.sdk.core.http.HttpMediaType;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
+import com.ibm.cloud.sdk.core.util.RequestUtils;
 
 /**
  * VpcInstanceAuthenticator implements an authentication scheme in which it
@@ -124,7 +125,8 @@ public class VpcInstanceAuthenticator
 
   // The default ctor is hidden to force the use of the non-default ctors.
   protected VpcInstanceAuthenticator() {
-  }
+    setUserAgent(RequestUtils.buildUserAgent("vpc-instance-authenticator"));
+}
 
   /**
    * Constructs an IamAuthenticator instance from the configuration contained in
@@ -133,6 +135,7 @@ public class VpcInstanceAuthenticator
    * @param builder the Builder instance containing the configuration to be used
    */
   protected VpcInstanceAuthenticator(Builder builder) {
+    this();
     this.iamProfileCrn = builder.iamProfileCrn;
     this.iamProfileId = builder.iamProfileId;
     this.url = builder.url;
@@ -309,6 +312,7 @@ public class VpcInstanceAuthenticator
       builder.header(HttpHeaders.ACCEPT, HttpMediaType.APPLICATION_JSON);
       builder.header(HttpHeaders.CONTENT_TYPE, HttpMediaType.APPLICATION_JSON);
       builder.header(HttpHeaders.AUTHORIZATION, "Bearer " + instanceIdentityToken);
+      builder.header(HttpHeaders.USER_AGENT, getUserAgent());
 
       // Next, construct the optional request body to specify the linked IAM profile.
       // We previously verified that at most one of IBMProfileCRN or IAMProfileID was specified by the user,

--- a/src/main/java/com/ibm/cloud/sdk/core/util/RequestUtils.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/util/RequestUtils.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2015, 2019.
+ * (C) Copyright IBM Corp. 2015, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Utility functions to use when creating a {@link com.ibm.cloud.sdk.core.http.RequestBuilder }.
@@ -158,18 +160,31 @@ public final class RequestUtils {
 
   /**
    * Builds the user agent using System properties.
+   * @param subComponent an optional sub-component to be included in the user agent value
    *
    * @return the string that represents the user agent
    */
-  private static String buildUserAgent() {
-    final List<String> details = new ArrayList<>();
-    for (String propertyName : properties) {
-      details.add(propertyName + "=" + System.getProperty(propertyName));
+  public static String buildUserAgent(String subComponent) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("ibm-java-sdk-core");
+    if (StringUtils.isNotEmpty(subComponent)) {
+      sb.append("/");
+      sb.append(subComponent);
     }
+    sb.append("-");
+    sb.append(loadCoreVersion());
+    sb.append(" ");
+    sb.append(getSystemInfo());
 
-    return "ibm-java-sdk-core-" + loadCoreVersion() + " " + getSystemInfo();
+    return sb.toString();
   }
 
+  /**
+   * Returns the "system info" which consists of the values of system properties
+   * whose names are contained in the "properties" list defined above.
+   *
+   * @return the system info associated with the current environment
+   */
   public static String getSystemInfo() {
     final List<String> details = new ArrayList<>();
     for (String propertyName : properties) {
@@ -181,12 +196,11 @@ public final class RequestUtils {
 
   /**
    * Gets the user agent.
-   *
    * @return the user agent
    */
   public static synchronized String getUserAgent() {
     if (userAgent == null) {
-      userAgent = buildUserAgent();
+      userAgent = buildUserAgent(null);
     }
     return userAgent;
   }

--- a/src/test/java/com/ibm/cloud/sdk/core/security/VpcInstanceAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/security/VpcInstanceAuthenticatorTest.java
@@ -35,6 +35,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.ibm.cloud.sdk.core.http.HttpHeaders;
+import com.ibm.cloud.sdk.core.security.VpcTokenResponse;
 import com.ibm.cloud.sdk.core.service.exception.ServiceResponseException;
 import com.ibm.cloud.sdk.core.test.BaseServiceUnitTest;
 import com.ibm.cloud.sdk.core.util.Clock;
@@ -246,6 +247,7 @@ public class VpcInstanceAuthenticatorTest extends BaseServiceUnitTest {
     Headers actualHeaders = vpcIamTokenRequest.getHeaders();
     assertNotNull(actualHeaders);
     assertEquals(actualHeaders.get(HttpHeaders.AUTHORIZATION), "Bearer " + instanceIdentityToken);
+    assertTrue(actualHeaders.get(HttpHeaders.USER_AGENT).startsWith("ibm-java-sdk-core/vpc-instance-authenticator"));
   }
 
   @Test

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/ContainerAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/ContainerAuthenticatorTest.java
@@ -496,6 +496,7 @@ public class ContainerAuthenticatorTest extends BaseServiceUnitTest {
     assertEquals(actualHeaders.get("header1"), "value1");
     assertEquals(actualHeaders.get("header2"), "value2");
     assertEquals(actualHeaders.get("Host"), "iam.cloud.ibm.com:81");
+    assertTrue(actualHeaders.get(HttpHeaders.USER_AGENT).startsWith("ibm-java-sdk-core/container-authenticator"));
 
     // Authenticator should just return the same token this time since we have a valid one stored.
     requestBuilder = new Request.Builder().url("https://test.com");

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019, 2023.
+ * (C) Copyright IBM Corp. 2019, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -32,6 +32,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.ibm.cloud.sdk.core.http.HttpHeaders;
 import com.ibm.cloud.sdk.core.security.Authenticator;
 import com.ibm.cloud.sdk.core.security.CloudPakForDataAuthenticator;
 import com.ibm.cloud.sdk.core.security.Cp4dToken;
@@ -448,6 +449,7 @@ public class Cp4dAuthenticatorTest extends BaseServiceUnitTest {
     assertNotNull(tokenServerRequest);
     assertNotNull(tokenServerRequest.getHeaders());
     Headers actualHeaders = tokenServerRequest.getHeaders();
+    assertTrue(actualHeaders.get(HttpHeaders.USER_AGENT).startsWith("ibm-java-sdk-core/cp4d-authenticator"));
     assertEquals("value1", actualHeaders.get("header1"));
     assertEquals("value2", actualHeaders.get("header2"));
 

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dServiceAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dServiceAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2022, 2023.
+ * (C) Copyright IBM Corp. 2022, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -32,6 +32,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.ibm.cloud.sdk.core.http.HttpHeaders;
 import com.ibm.cloud.sdk.core.security.Authenticator;
 import com.ibm.cloud.sdk.core.security.CloudPakForDataServiceAuthenticator;
 import com.ibm.cloud.sdk.core.security.Cp4dTokenResponse;
@@ -576,6 +577,7 @@ public class Cp4dServiceAuthenticatorTest extends BaseServiceUnitTest {
     assertEquals("value1", actualHeaders.get("header1"));
     assertEquals("value2", actualHeaders.get("header2"));
     assertEquals("cp4d.cloud.ibm.com:81", actualHeaders.get("Host"));
+    assertTrue(actualHeaders.get(HttpHeaders.USER_AGENT).startsWith("ibm-java-sdk-core/cp4d-service-authenticator"));
 
     // Authenticator should just return the same token this time since we have a valid one stored.
     requestBuilder = new Request.Builder().url("https://test.com");

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dServiceInstanceAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/Cp4dServiceInstanceAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2019, 2023.
+ * (C) Copyright IBM Corp. 2019, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -32,6 +32,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.ibm.cloud.sdk.core.http.HttpHeaders;
 import com.ibm.cloud.sdk.core.security.Authenticator;
 import com.ibm.cloud.sdk.core.security.CloudPakForDataServiceInstanceAuthenticator;
 import com.ibm.cloud.sdk.core.security.Cp4dServiceInstanceTokenResponse;
@@ -488,6 +489,8 @@ public class Cp4dServiceInstanceAuthenticatorTest extends BaseServiceUnitTest {
     Headers actualHeaders = tokenServerRequest.getHeaders();
     assertEquals("value1", actualHeaders.get("header1"));
     assertEquals("value2", actualHeaders.get("header2"));
+    assertTrue(
+        actualHeaders.get(HttpHeaders.USER_AGENT).startsWith("ibm-java-sdk-core/cp4d-service-instance-authenticator"));
 
     // Authenticator should just return the same token this time since we have a valid one stored.
     requestBuilder = new Request.Builder().url("https://test.com");

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/IamAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/IamAuthenticatorTest.java
@@ -459,6 +459,7 @@ public class IamAuthenticatorTest extends BaseServiceUnitTest {
     Headers actualHeaders = tokenServerRequest.getHeaders();
     assertEquals("value1", actualHeaders.get("header1"));
     assertEquals("value2", actualHeaders.get("header2"));
+    assertTrue(actualHeaders.get(HttpHeaders.USER_AGENT).startsWith("ibm-java-sdk-core/iam-authenticator"));
     assertEquals("iam.cloud.ibm.com:81", actualHeaders.get("Host"));
 
     // Authenticator should just return the same token this time since we have a valid one stored.

--- a/src/test/java/com/ibm/cloud/sdk/core/test/security/MCSPAuthenticatorTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/security/MCSPAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2023.
+ * (C) Copyright IBM Corp. 2023, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -35,6 +35,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.ibm.cloud.sdk.core.http.HttpHeaders;
 import com.ibm.cloud.sdk.core.security.Authenticator;
 import com.ibm.cloud.sdk.core.security.MCSPAuthenticator;
 import com.ibm.cloud.sdk.core.security.MCSPTokenResponse;
@@ -332,6 +333,7 @@ public class MCSPAuthenticatorTest extends BaseServiceUnitTest {
     assertEquals("value1", actualHeaders.get("header1"));
     assertEquals("value2", actualHeaders.get("header2"));
     assertEquals("mcsp.cloud.ibm.com:81", actualHeaders.get("Host"));
+    assertTrue(actualHeaders.get(HttpHeaders.USER_AGENT).startsWith("ibm-java-sdk-core/mcsp-authenticator"));
 
     // Authenticator should just return the same token this time since we have a valid one stored.
     requestBuilder = new Request.Builder().url("https://test.com");

--- a/src/test/java/com/ibm/cloud/sdk/core/util/RequestUtilsTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/util/RequestUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2015, 2023.
+ * (C) Copyright IBM Corp. 2015, 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -130,6 +130,12 @@ public class RequestUtilsTest {
   public void testUserAgent() {
     assertNotNull(RequestUtils.getUserAgent());
     assertTrue(RequestUtils.getUserAgent().startsWith("ibm-java-sdk-core-"));
+  }
+
+  @Test
+  public void testBuildUserAgent() {
+    assertTrue(RequestUtils.buildUserAgent(null).startsWith("ibm-java-sdk-core-"));
+    assertTrue(RequestUtils.buildUserAgent("sub-component").startsWith("ibm-java-sdk-core/sub-component-"));
   }
 
   @Test


### PR DESCRIPTION
This commit updates our various request-based authenticators so that the User-Agent header is included with each outbound token request. The value of the User-Agent header will be of the form "ibm-java-sdk-core/<authenticator-type>-<core-version> <os-info>".