### PR TITLE
feat(ContainerAuthenticator): enhance ContainerAuthenticator to support Code Engine workload

### DIFF
--- a/Authentication.md
+++ b/Authentication.md
@@ -336,10 +336,10 @@ ExampleService service = ExampleService.newInstance("example_service");
 ## Container Authentication
 The `ContainerAuthenticator` is intended to be used by application code
 running inside a compute resource managed by the IBM Kubernetes Service (IKS)
-in which a secure compute resource token (CR token) has been stored in a file
-within the compute resource's local file system.
+or IBM Cloud Code Engine in which a secure compute resource token (CR token)
+has been stored in a file within the compute resource's local file system.
 The CR token is similar to an IAM apikey except that it is managed automatically by
-the compute resource provider (IKS).
+the compute resource provider (IKS or Code Engine).
 This allows the application developer to:
 - avoid storing credentials in application code, configuration files or a password vault
 - avoid managing or rotating credentials
@@ -359,7 +359,9 @@ The IAM access token is added to each outbound request in the `Authorization` he
 
 - crTokenFilename: (optional) the name of the file containing the injected CR token value.
 If not specified, then the authenticator will first try `/var/run/secrets/tokens/vault-token`
-and then `/var/run/secrets/tokens/sa-token` as the default value (first file found is used).
+and then `/var/run/secrets/tokens/sa-token` and finally
+`/var/run/secrets/codeengine.cloud.ibm.com/compute-resource-token/token` as the default value
+(first file found is used).
 The application must have `read` permissions on the file containing the CR token value.
 
 - iamProfileName: (optional) the name of the linked trusted IAM profile to be used when obtaining the

--- a/src/main/java/com/ibm/cloud/sdk/core/security/ContainerAuthenticator.java
+++ b/src/main/java/com/ibm/cloud/sdk/core/security/ContainerAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021, 2024.
+ * (C) Copyright IBM Corp. 2021, 2025.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -43,6 +43,8 @@ public class ContainerAuthenticator extends IamRequestBasedAuthenticator impleme
   private static final String OPERATION_PATH = "/identity/token";
   private static final String DEFAULT_CR_TOKEN_FILENAME1 = "/var/run/secrets/tokens/vault-token";
   private static final String DEFAULT_CR_TOKEN_FILENAME2 = "/var/run/secrets/tokens/sa-token";
+  private static final String
+    DEFAULT_CR_TOKEN_FILENAME3 = "/var/run/secrets/codeengine.cloud.ibm.com/compute-resource-token/token";
   private static final String ERRORMSG_CR_TOKEN_ERROR = "Error reading CR token file: %s";
 
   // Properties specific to a ContainerAuthenticator.
@@ -385,11 +387,15 @@ public class ContainerAuthenticator extends IamRequestBasedAuthenticator impleme
               // Try to read from the file specified by the user.
               crToken = readFile(getCrTokenFilename());
           } else {
-              // If no filename was supplied by the user, then try our two default filenames.
+              // If no filename was supplied by the user, then try our three default filenames.
               try {
                   crToken = readFile(DEFAULT_CR_TOKEN_FILENAME1);
               } catch (Throwable t) {
-                  crToken = readFile(DEFAULT_CR_TOKEN_FILENAME2);
+                  try {
+                    crToken = readFile(DEFAULT_CR_TOKEN_FILENAME2);
+                  } catch (Throwable t1) {
+                    crToken = readFile(DEFAULT_CR_TOKEN_FILENAME3);
+                  }
               }
           }
           return crToken;


### PR DESCRIPTION
This pull request extends the existing ContainerAuthenticator to be aware of the hard-coded compute resource token path used by Code Engine. This allows a seamless usage of that authenticator and a move of workload between IKS/ROKS/Code Engine without changing a single line of code.

Documentation is adjusted to mention Code Engine in the context of the ContainerAuthenticator.