### PR TITLE
fix(build): mark secret as false positive

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-05-27T21:34:41Z",
+  "generated_at": "2025-05-30T15:23:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -129,6 +129,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 729,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "CHANGELOG.md": [
+      {
+        "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6,
         "type": "Secret Keyword",
         "verified_result": null
       }


### PR DESCRIPTION
This detect-secrets violation occurs due to the change that was made to CHANGELOG.md.  Just updated .secrets.baseline to suppress it.