### PR TITLE
fix(build): bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,12 @@
         <jacoco-plugin-version>0.8.10</jacoco-plugin-version>
         <compiler-plugin-version>3.11.0</compiler-plugin-version>
         <okhttp3-version>4.12.0</okhttp3-version>
-        <gson-version>2.13.0</gson-version>
+        <gson-version>2.13.1</gson-version>
         <commons-codec-version>1.18.0</commons-codec-version>
         <commons-io-version>2.19.0</commons-io-version>
         <commons-lang3-version>3.18.0</commons-lang3-version>
         <rx-version>2.2.21</rx-version>
-        <mockito-version>5.17.0</mockito-version>
+        <mockito-version>5.18.0</mockito-version>
         <maven-deploy-plugin-version>3.1.1</maven-deploy-plugin-version>
         <nexus-staging-plugin-version>1.6.13</nexus-staging-plugin-version>
         <maven-gpg-plugin-version>3.1.0</maven-gpg-plugin-version>


### PR DESCRIPTION
Bumps dependencies to their newest version. Gson to 2.13.1, mockito to 5.18.0